### PR TITLE
[minor] No default None value for ShotgunOverlayWidget parent (ctor)

### DIFF
--- a/python/overlay_widget/shotgun_overlay_widget.py
+++ b/python/overlay_widget/shotgun_overlay_widget.py
@@ -29,7 +29,7 @@ class ShotgunOverlayWidget(QtGui.QWidget):
     MODE_INFO_TEXT = 3
     MODE_INFO_PIXMAP = 4
 
-    def __init__(self, parent=None):
+    def __init__(self, parent):
         """
         Constructor
         """


### PR DESCRIPTION
Since we call `parent.installEventFilter` right after, this will fail if the constructor had a default value. Clarifies that a value is really expected and needed.