### PR TITLE
Adds the ability to hide the screenshot button.

### DIFF
--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -40,10 +40,12 @@ class ActivityStreamWidget(QtGui.QWidget):
     playback_requested = QtCore.Signal(dict)   
      
     
-    def __init__(self, parent):
+    def __init__(self, parent, allow_screenshots=True):
         """
         :param parent: QT parent object
         :type parent: :class:`~PySide.QtGui.QWidget`
+        :param allow_screenshots: Allow or disallow screenshots, defaults to True.
+        :type  allow_screenshots: :class:`Boolean`
         """
         # first, call the base class and let it do its thing.
         QtGui.QWidget.__init__(self, parent)
@@ -52,6 +54,10 @@ class ActivityStreamWidget(QtGui.QWidget):
         # now load in the UI that was created in the UI designer
         self.ui = Ui_ActivityStreamWidget() 
         self.ui.setupUi(self)
+
+        # customizations
+        self._allow_screenshots = allow_screenshots
+        self.ui.note_widget.allow_screenshots(allow_screenshots)
         
         # apply styling
         self._load_stylesheet()
@@ -83,7 +89,6 @@ class ActivityStreamWidget(QtGui.QWidget):
         self._sg_entity_dict = None
         self._entity_type = None
         self._entity_id = None
-
 
     def set_bg_task_manager(self, task_manager):
         """
@@ -532,7 +537,12 @@ class ActivityStreamWidget(QtGui.QWidget):
         """
         Callback when someone clicks reply on a given note
         """
-        reply_dialog = ReplyDialog(self, self._task_manager, note_id)
+        reply_dialog = ReplyDialog(
+            self,
+            self._task_manager,
+            note_id,
+            allow_screenshots=self._allow_screenshots,
+        )
         
         #position the reply modal dialog above the activity stream scroll area
         pos = self.mapToGlobal(self.ui.activity_stream_scroll_area.pos())

--- a/python/activity_stream/dialog_reply.py
+++ b/python/activity_stream/dialog_reply.py
@@ -17,12 +17,14 @@ class ReplyDialog(QtGui.QDialog):
     This is used when someone clicks on the reply button for a note.
     """
     
-    def __init__(self, parent, bg_task_manager, note_id):
+    def __init__(self, parent, bg_task_manager, note_id, allow_screenshots=True):
         """
         :param parent: QT parent object
         :type parent: :class:`PySide.QtGui.QWidget`
         :param bg_task_manager: Task manager to use to fetch sg data.
-        :type  bg_task_manager: :class:`~tk-framework-shotgunutils:task_manager.BackgroundTaskManager` 
+        :type  bg_task_manager: :class:`~tk-framework-shotgunutils:task_manager.BackgroundTaskManager`
+        :param allow_screenshots: Boolean to allow or disallow screenshots, defaults to True.
+        :type  allow_screenshots: :class:`Boolean`
         """        
         # first, call the base class and let it do its thing.
         QtGui.QDialog.__init__(self, parent)
@@ -35,6 +37,7 @@ class ReplyDialog(QtGui.QDialog):
         self.ui.note_widget.data_updated.connect(self.close_after_create)
         self.ui.note_widget.close_clicked.connect(self.close_after_cancel)
         self.ui.note_widget.set_current_entity("Note", note_id)
+        self.ui.note_widget.allow_screenshots(allow_screenshots)
         
         self.setWindowFlags(QtCore.Qt.Dialog | QtCore.Qt.FramelessWindowHint)        
         

--- a/python/note_input_widget/widget.py
+++ b/python/note_input_widget/widget.py
@@ -480,6 +480,15 @@ class NoteInputWidget(QtGui.QWidget):
         
     ###########################################################################
     # public interface
+
+    def allow_screenshots(self, state):
+        """
+        Allows or disallows screenshots.
+
+        :param state: Allow or disallow screenshots.
+        :type  state: :class:`Boolean`
+        """
+        self.ui.screenshot.setVisible(bool(state))
         
     def open_editor(self):
         """


### PR DESCRIPTION
When entering new notes or replying to an existing note, screenshots can be disallowed. The result is that the screenshot buttons are hidden away.