### PR TITLE
Prevents init from happening multiple times

### DIFF
--- a/python/shotgun_fields/shotgun_field_manager.py
+++ b/python/shotgun_fields/shotgun_field_manager.py
@@ -162,6 +162,10 @@ class ShotgunFieldManager(QtCore.QObject):
         Initialize the task manager.  When initialization is complete the initialized signal
         will be emitted.
         """
+        if self._initialized:
+            # already initialized
+            return
+
         if self._task_manager is None:
             # create our own task manager if one wasn't passed in
             task_manager = sgtk.platform.import_framework("tk-framework-shotgunutils", "task_manager")


### PR DESCRIPTION
Minor bug fix that prevents from an init being called multiple times and thus registering the task manager multiple times with the shotgun globals module.