### PR TITLE
#36162 Note/Reply entity creation is broadcast via an entity_created signal.

### DIFF
--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -94,8 +94,12 @@ class ActivityStreamWidget(QtGui.QWidget):
         self._entity_type = None
         self._entity_id = None
 
-        # When a ReplyDialog is active it will be stored here.
-        self.reply_dialog = None
+        self.reply_dialog = ReplyDialog(
+            self,
+            self._task_manager,
+            note_id=None,
+            allow_screenshots=self._allow_screenshots,
+        )
 
     def set_bg_task_manager(self, task_manager):
         """
@@ -126,8 +130,7 @@ class ActivityStreamWidget(QtGui.QWidget):
         Returns the NoteInputWidget contained within the ActivityStreamWidget.
         Note that this is the widget used for NEW note input and not Note
         replies. To get the NoteInputWidget used for Note replies, access can
-        be found via reply_widget.note_widget if a reply widget is currently
-        active.
+        be found via reply_dialog.note_widget.
         """
         return self.ui.note_widget
 
@@ -604,28 +607,21 @@ class ActivityStreamWidget(QtGui.QWidget):
         """
         Callback when someone clicks reply on a given note
         """
-        reply_dialog = ReplyDialog(
-            self,
-            self._task_manager,
-            note_id,
-            allow_screenshots=self._allow_screenshots,
-        )
-        
-        #position the reply modal dialog above the activity stream scroll area
+        self.reply_dialog.note_id = note_id
+
+        # Position the reply modal dialog above the activity stream scroll area.
         pos = self.mapToGlobal(self.ui.activity_stream_scroll_area.pos())
-        x_pos = pos.x() + (self.ui.activity_stream_scroll_area.width() / 2) - (reply_dialog.width() / 2) - 10         
-        y_pos = pos.y() + (self.ui.activity_stream_scroll_area.height() / 2) - (reply_dialog.height() / 2) - 20
-        reply_dialog.move(x_pos, y_pos)
+        x_pos = pos.x() + (self.ui.activity_stream_scroll_area.width() / 2) - (self.reply_dialog.width() / 2) - 10         
+        y_pos = pos.y() + (self.ui.activity_stream_scroll_area.height() / 2) - (self.reply_dialog.height() / 2) - 20
+        self.reply_dialog.move(x_pos, y_pos)
         
         # and pop it
         try:
-            self.reply_dialog = reply_dialog
             self.__small_overlay.show()
-            if reply_dialog.exec_() == QtGui.QDialog.Accepted:
+            if self.reply_dialog.exec_() == QtGui.QDialog.Accepted:
                 self.load_data(self._sg_entity_dict)
         finally:
             self.__small_overlay.hide()
-            self.reply_dialog = None
         
     def _on_note_submitted(self):
         """

--- a/python/activity_stream/data_manager.py
+++ b/python/activity_stream/data_manager.py
@@ -370,7 +370,7 @@ class ActivityStreamDataHandler(QtCore.QObject):
                                         "thumbnail_type": self.THUMBNAIL_CREATED_BY}
 
             else:
-                self._bundle.log_warning("No thumbnail found for this note!")
+                self._bundle.log_debug("No thumbnail found for this note!")
             
         elif created_by and created_by.get("image") and self._sg_data_retriever:
             # for all other activities, the thumbnail reflects who

--- a/python/activity_stream/dialog_reply.py
+++ b/python/activity_stream/dialog_reply.py
@@ -48,7 +48,7 @@ class ReplyDialog(QtGui.QDialog):
     @property
     def note_widget(self):
         """
-        Returns the underlying note_input_widget.NoteInputWidget.
+        Returns the underlying :class:`~note_input_widget.NoteInputWidget`.
         """
         return self.ui.note_widget
 

--- a/python/activity_stream/dialog_reply.py
+++ b/python/activity_stream/dialog_reply.py
@@ -17,7 +17,7 @@ class ReplyDialog(QtGui.QDialog):
     This is used when someone clicks on the reply button for a note.
     """
     
-    def __init__(self, parent, bg_task_manager, note_id, allow_screenshots=True):
+    def __init__(self, parent, bg_task_manager, note_id=None, allow_screenshots=True):
         """
         :param parent: QT parent object
         :type parent: :class:`PySide.QtGui.QWidget`
@@ -32,6 +32,8 @@ class ReplyDialog(QtGui.QDialog):
         # now load in the UI that was created in the UI designer
         self.ui = Ui_ReplyDialog() 
         self.ui.setupUi(self)
+
+        self._note_id = note_id
         
         self.ui.note_widget.set_bg_task_manager(bg_task_manager)        
         self.ui.note_widget.data_updated.connect(self.close_after_create)
@@ -39,7 +41,35 @@ class ReplyDialog(QtGui.QDialog):
         self.ui.note_widget.set_current_entity("Note", note_id)
         self.ui.note_widget.allow_screenshots(allow_screenshots)
         
-        self.setWindowFlags(QtCore.Qt.Dialog | QtCore.Qt.FramelessWindowHint)        
+        self.setWindowFlags(QtCore.Qt.Dialog | QtCore.Qt.FramelessWindowHint)
+
+    @property
+    def note_widget(self):
+        """
+        Returns the underlying note_input_widget.NoteInputWidget.
+        """
+        return self.ui.note_widget
+
+    def _get_note_id(self):
+        """
+        Gets the entity id number for the parent Note entity
+        being replied to.
+
+        :returns:   int
+        """
+        return self._note_id
+
+    def _set_note_id(self, note_id):
+        """
+        Sets the entity id number for the parent Note entity
+        being replied to.
+
+        :param note_id: Integer id of a Note entity in Shotgun.
+        """
+        self.ui.note_widget.set_current_entity("Note", note_id)
+        self._note_id = note_id
+
+    note_id = QtCore.Property(int, _get_note_id, _set_note_id)
         
     def close_after_create(self):
         """
@@ -60,6 +90,6 @@ class ReplyDialog(QtGui.QDialog):
         self.ui.note_widget.open_editor()
     
     def closeEvent(self, event):
-        self.ui.note_widget.destroy()
+        self.ui.note_widget.clear()
         # ok to close
         event.accept()

--- a/python/activity_stream/dialog_reply.py
+++ b/python/activity_stream/dialog_reply.py
@@ -23,6 +23,8 @@ class ReplyDialog(QtGui.QDialog):
         :type parent: :class:`PySide.QtGui.QWidget`
         :param bg_task_manager: Task manager to use to fetch sg data.
         :type  bg_task_manager: :class:`~tk-framework-shotgunutils:task_manager.BackgroundTaskManager`
+        :param note_id: The entity id number of the Note entity being replied to.
+        :type  note_id: :class:`int`
         :param allow_screenshots: Boolean to allow or disallow screenshots, defaults to True.
         :type  allow_screenshots: :class:`Boolean`
         """        

--- a/python/activity_stream/widget_note.py
+++ b/python/activity_stream/widget_note.py
@@ -225,10 +225,10 @@ class NoteWidget(ActivityStreamBaseWidget):
         self._set_timestamp(data, self.ui.date)
         
         # set the main note text
-        self.ui.content.setText(data["content"])
+        self.ui.content.setText(data.get("content", ""))
         
         # format note links        
-        html_link_box_data = data["note_links"] + data["tasks"]
+        html_link_box_data = data.get("note_links", []) + data.get("tasks", [])
         links_html = self.__generate_note_links_table(html_link_box_data)
 
         # self.ui.links.setText(links_html)

--- a/python/activity_stream/widget_note.py
+++ b/python/activity_stream/widget_note.py
@@ -224,7 +224,14 @@ class NoteWidget(ActivityStreamBaseWidget):
         # date of activity)
         self._set_timestamp(data, self.ui.date)
         
-        # set the main note text
+        # Set the main note text. For this, and for the note links and
+        # task keys below, we are treating it with kids gloves to make
+        # sure that we don't end up raising a KeyError in a way that
+        # makes it to the user. This is due to the possibility of having
+        # a malformed Cut entity in Shotgun and SHOULD be handled at a
+        # higher level than this widget, but we're still going to be
+        # careful here, because we saw this bug crop up during Cut Support
+        # QA.
         self.ui.content.setText(data.get("content", ""))
         
         # format note links        

--- a/python/note_input_widget/widget.py
+++ b/python/note_input_widget/widget.py
@@ -46,7 +46,7 @@ class NoteInputWidget(QtGui.QWidget):
     # Emitted when a Note or Reply entity is created. The
     # entity type as a string and id as an int will be
     # provided.
-    entity_created = QtCore.Signal(str, int)
+    entity_created = QtCore.Signal(object)
     
     
     def __init__(self, parent):
@@ -312,7 +312,8 @@ class NoteInputWidget(QtGui.QWidget):
             
         self.__upload_thumbnail(note_link, sg, data)
         self.__upload_attachments(note_link, sg, data)
-        self.entity_created.emit("Reply", sg_reply_data["id"])
+
+        return sg_reply_data
         
     def _async_submit_note(self, sg, data):
         # note - no logging in here, as I am not sure how all 
@@ -449,7 +450,8 @@ class NoteInputWidget(QtGui.QWidget):
         
         self.__upload_thumbnail(sg_note_data, sg, data)
         self.__upload_attachments(sg_note_data, sg, data)
-        self.entity_created.emit("Note", sg_note_data["id"])
+
+        return sg_note_data
 
     def __upload_attachments(self, parent_entity, sg, data):
         """
@@ -545,6 +547,7 @@ class NoteInputWidget(QtGui.QWidget):
             self.clear()
             self._bundle.log_debug("Update call complete! Return data: %s" % data)
             self.data_updated.emit()
+            self.entity_created.emit(data["return_value"])
             
         
     def __format_thumbnail(self, pixmap_obj):

--- a/python/note_input_widget/widget.py
+++ b/python/note_input_widget/widget.py
@@ -33,6 +33,9 @@ class NoteInputWidget(QtGui.QWidget):
         replied to. 
     :signal close_clicked: Emitted if a user chooses to cancel the note 
         creation by clicking the X button.
+    :signal entity_created: Emitted when a Shotgun entity is created, which
+        will be either a Note or Reply entity, depending on situation. The
+        entity dictionary, as provided by the API, will be sent.
     """
     
     _EDITOR_WIDGET_INDEX = 0
@@ -46,6 +49,8 @@ class NoteInputWidget(QtGui.QWidget):
     # Emitted when a Note or Reply entity is created. The
     # entity type as a string and id as an int will be
     # provided.
+    #
+    # dict(entity_type="Note", id=1234)
     entity_created = QtCore.Signal(object)
     
     
@@ -289,9 +294,15 @@ class NoteInputWidget(QtGui.QWidget):
         
     def _async_submit_reply(self, sg, data):
         """
-        Create a new reply
+        Provides functionality for creating a new Reply entity
+        asynchronously by providing a signature that is friendly
+        for use with :class:`~tk-framework-shotgunutils:shotgun_data.ShotgunDataRetriever`.
+
+        :param sg:      A Shotgun API handle.
+        :param data:    A dictionary as created by :meth:`NoteInputWidget._submit`
+
+        :returns:       A Shotgun entity dictionary for the Reply that was created.
         """
-        
         note_link = data["entity"]
         
         # this is an entity - so create a note and link it
@@ -316,6 +327,16 @@ class NoteInputWidget(QtGui.QWidget):
         return sg_reply_data
         
     def _async_submit_note(self, sg, data):
+        """
+        Provides functionality for creating a new Note entity
+        asynchronously by providing a signature that is friendly
+        for use with :class:`~tk-framework-shotgunutils:shotgun_data.ShotgunDataRetriever`.
+
+        :param sg:      A Shotgun API handle.
+        :param data:    A dictionary as created by :meth:`NoteInputWidget._submit`
+
+        :returns:       A Shotgun entity dictionary for the Note that was created.
+        """
         # note - no logging in here, as I am not sure how all 
         # engines currently react to log_debug() async.
         

--- a/python/note_input_widget/widget.py
+++ b/python/note_input_widget/widget.py
@@ -42,6 +42,11 @@ class NoteInputWidget(QtGui.QWidget):
     # emitted when shotgun has been updated
     data_updated = QtCore.Signal()
     close_clicked = QtCore.Signal()
+
+    # Emitted when a Note or Reply entity is created. The
+    # entity type as a string and id as an int will be
+    # provided.
+    entity_created = QtCore.Signal(str, int)
     
     
     def __init__(self, parent):
@@ -290,7 +295,7 @@ class NoteInputWidget(QtGui.QWidget):
         note_link = data["entity"]
         
         # this is an entity - so create a note and link it
-        sg.create("Reply", {"content": data["text"], "entity": note_link})
+        sg_reply_data = sg.create("Reply", {"content": data["text"], "entity": note_link})
 
         # if there are any recipients, make sure they are added to the note
         # but as CCs
@@ -306,8 +311,8 @@ class NoteInputWidget(QtGui.QWidget):
                       {"addressings_cc": updated_links})
             
         self.__upload_thumbnail(note_link, sg, data)
-        self.__upload_attachments(note_link, sg, data)     
-                
+        self.__upload_attachments(note_link, sg, data)
+        self.entity_created.emit("Reply", sg_reply_data["id"])
         
     def _async_submit_note(self, sg, data):
         # note - no logging in here, as I am not sure how all 
@@ -444,7 +449,7 @@ class NoteInputWidget(QtGui.QWidget):
         
         self.__upload_thumbnail(sg_note_data, sg, data)
         self.__upload_attachments(sg_note_data, sg, data)
-        
+        self.entity_created.emit("Note", sg_note_data["id"])
 
     def __upload_attachments(self, parent_entity, sg, data):
         """


### PR DESCRIPTION
This allows higher-level widgets to perform additional tasks or alter the resulting entity after it is created.