### PR TITLE
PlaybackLabel can now be set to be non-interactive.

### DIFF
--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -71,6 +71,7 @@ class ActivityStreamWidget(QtGui.QWidget):
         # customizations
         self._allow_screenshots = True
         self._show_sg_stream_button = True
+        self._version_items_playable = True
         
         # apply styling
         self._load_stylesheet()
@@ -184,6 +185,24 @@ class ActivityStreamWidget(QtGui.QWidget):
         bool,
         _get_show_sg_stream_button,
         _set_show_sg_stream_button,
+    )
+
+    def _get_version_items_playable(self):
+        """
+        Whether the label representing a created Version entity is shown
+        as being "playable" within the UI. If True, then a play icon is
+        visible over the thumbnail image, and no icon overlay is shown
+        when False.
+        """
+        return self._version_items_playable
+
+    def _set_version_items_playable(self, state):
+        self._version_items_playable = bool(state)
+
+    version_items_playable = QtCore.Property(
+        bool,
+        _get_version_items_playable,
+        _set_version_items_playable,
     )
         
     ############################################################################
@@ -500,6 +519,7 @@ class ActivityStreamWidget(QtGui.QWidget):
             if data["primary_entity"]["type"] in ["Version", "PublishedFile", "TankPublishedFile"]:
                 # full on 'new item' widget with thumbnail, description etc.
                 widget = NewItemWidget(self)
+                widget.interactive = self.version_items_playable
             
             elif data["primary_entity"]["type"] == "Note":
                 # new note

--- a/python/activity_stream/widget_new_item.py
+++ b/python/activity_stream/widget_new_item.py
@@ -35,6 +35,7 @@ class NewItemWidget(ActivityStreamBaseWidget):
         # now load in the UI that was created in the UI designer
         self.ui = Ui_NewItemWidget() 
         self.ui.setupUi(self)
+        self._interactive = True
         
         # thumbnails are hidden by default, only to appear
         # for created objects that have them set 
@@ -43,10 +44,34 @@ class NewItemWidget(ActivityStreamBaseWidget):
         # make sure that click on hyperlinks bubble up
         self.ui.footer.linkActivated.connect(self._entity_request_from_url)
         self.ui.header_left.linkActivated.connect(self._entity_request_from_url)
-        
-        self.ui.details_thumb.playback_clicked.connect(lambda sg_data: self.playback_requested.emit(sg_data))
-        
-        self.ui.user_thumb.entity_requested.connect(lambda entity_type, entity_id: self.entity_requested.emit(entity_type, entity_id))
+        self.ui.details_thumb.playback_clicked.connect(
+            lambda sg_data: self.playback_requested.emit(sg_data)
+        )
+        self.ui.user_thumb.entity_requested.connect(
+            lambda entity_type, entity_id: self.entity_requested.emit(
+                entity_type,
+                entity_id,
+            )
+        )
+
+    ##############################################################################
+    # properties
+
+    def _get_interactive(self):
+        """
+        Whether the new item label is interactive, showing a play icon.
+        """
+        return self._interactive
+
+    def _set_interactive(self, state):
+        self._interactive = bool(state)
+        self.ui.details_thumb.interactive = self._interactive
+
+    interactive = QtCore.Property(
+        bool,
+        _get_interactive,
+        _set_interactive,
+    )
         
     ##############################################################################
     # public interface

--- a/python/playback_label/playback_label.py
+++ b/python/playback_label/playback_label.py
@@ -94,10 +94,10 @@ class ShotgunPlaybackLabel(QtGui.QLabel):
     def _set_interactive(self, state):
         self._interactive = bool(state)
 
-        if not self._interactive:
-            self.unsetCursor()
-        elif self.playable:
+        if self.playable and self._interactive:
             self.setCursor(QtCore.Qt.PointingHandCursor)
+        else:
+            self.unsetCursor() 
 
     interactive = QtCore.Property(
         bool,


### PR DESCRIPTION
If not interactive, the play icon overlay will not be drawn, click events will not trigger playback signals, and the mouse icon won't be set to a finger pointer.