### PR TITLE
Refactors how annotated frames are attached to Notes and Replies.

### DIFF
--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -115,6 +115,14 @@ class ActivityStreamWidget(QtGui.QWidget):
             allow_screenshots=self._allow_screenshots,
         )
 
+        # We'll allow for a pre-note-creation callback. This is for additional
+        # pre-processing that needs to occur before a Note or Reply is created
+        # in Shotgun. This makes sure that the activity stream data coming down
+        # during the rescan after submission contains anything like additional
+        # attachments that this widget didn't explicitly handle itself prior to
+        # submission.
+        self._pre_submit_callback = None
+
         self.reply_dialog.note_widget.entity_created.connect(self._on_entity_created)
 
     def set_bg_task_manager(self, task_manager):
@@ -149,6 +157,28 @@ class ActivityStreamWidget(QtGui.QWidget):
         replies, access can be found via :meth:`ReplyDialog.note_widget`.
         """
         return self.ui.note_widget
+
+    def _get_pre_submit_callback(self):
+        """
+        The pre-submit callback. This is None if one is not set, or a Python
+        callable if it is. This callable is run prior to submission of a new
+        Note or Reply. Note that the first (and only) argument passed to the
+        callback will be the calling :class:`NoteInputWidget`.
+
+        :returns:   Python callable or None
+        """
+        return self._pre_submit_callback
+
+    def _set_pre_submit_callback(self, callback):
+        self._pre_submit_callback = callback
+        self.reply_dialog.note_widget.pre_submit_callback = callback
+        self.note_widget.pre_submit_callback = callback
+
+    pre_submit_callback = QtCore.Property(
+        object,
+        _get_pre_submit_callback,
+        _set_pre_submit_callback,
+    )
 
     def _get_allow_screenshots(self):
         """
@@ -677,4 +707,3 @@ class ActivityStreamWidget(QtGui.QWidget):
         """
         url = "%s/detail/%s/%s" % (self._bundle.sgtk.shotgun_url, self._entity_type, self._entity_id)
         QtGui.QDesktopServices.openUrl(QtCore.QUrl(url))
-

--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -174,8 +174,7 @@ class ActivityStreamWidget(QtGui.QWidget):
         self.reply_dialog.note_widget.pre_submit_callback = callback
         self.note_widget.pre_submit_callback = callback
 
-    pre_submit_callback = QtCore.Property(
-        object,
+    pre_submit_callback = property(
         _get_pre_submit_callback,
         _set_pre_submit_callback,
     )
@@ -191,8 +190,7 @@ class ActivityStreamWidget(QtGui.QWidget):
         self._allow_screenshots = bool(state)
         self.ui.note_widget.allow_screenshots(self._allow_screenshots)
 
-    allow_screenshots = QtCore.Property(
-        bool,
+    allow_screenshots = property(
         _get_allow_screenshots,
         _set_allow_screenshots,
     )
@@ -211,8 +209,7 @@ class ActivityStreamWidget(QtGui.QWidget):
         """
         self._show_sg_stream_button = bool(state)
 
-    show_sg_stream_button = QtCore.Property(
-        bool,
+    show_sg_stream_button = property(
         _get_show_sg_stream_button,
         _set_show_sg_stream_button,
     )
@@ -229,8 +226,7 @@ class ActivityStreamWidget(QtGui.QWidget):
     def _set_version_items_playable(self, state):
         self._version_items_playable = bool(state)
 
-    version_items_playable = QtCore.Property(
-        bool,
+    version_items_playable = property(
         _get_version_items_playable,
         _set_version_items_playable,
     )

--- a/python/note_input_widget/widget.py
+++ b/python/note_input_widget/widget.py
@@ -99,6 +99,7 @@ class NoteInputWidget(QtGui.QWidget):
         self.ui.remove_button.clicked.connect(self._remove_selected_attachments)
 
         # reset state of the UI
+        self.pre_submit_callback = None
         self.clear()
         
         
@@ -254,7 +255,10 @@ class NoteInputWidget(QtGui.QWidget):
                                           "Please add some content before submitting.")
             return
         
-        
+        # Call our pre-submit callback if we have one registered.
+        if self.pre_submit_callback:
+            self.pre_submit_callback(self)
+
         # hide hint label for better ux.
         self.ui.hint_label.hide()
         self.__overlay.start_spin()

--- a/python/shotgun_fields/bubble_widget.py
+++ b/python/shotgun_fields/bubble_widget.py
@@ -69,7 +69,7 @@ class BubbleWidget(QtGui.QFrame):
 
         # color the text to use the SG highlight color
         text_color = QtGui.QColor(
-            sgtk.constants.SG_STYLESHEET_CONSTANTS["SG_HIGHLIGHT_COLOR"]
+            sgtk.platform.current_bundle().style_constants["SG_HIGHLIGHT_COLOR"]
         )
         self.text_label = QtGui.QLabel(self)
         palette = self.text_label.palette()

--- a/python/shotgun_fields/entity_widget.py
+++ b/python/shotgun_fields/entity_widget.py
@@ -41,7 +41,7 @@ class EntityWidget(ElidedLabelBaseWidget):
         else:
             url_base = "%s/" % self._bundle.sgtk.shotgun_url
 
-        link_color = sgtk.constants.SG_STYLESHEET_CONSTANTS["SG_HIGHLIGHT_COLOR"]
+        link_color = sgtk.platform.current_bundle().style_constants["SG_HIGHLIGHT_COLOR"]
 
         entity_url = "%sdetail/%s/%d" % (url_base, value["type"], value["id"])
         entity_icon_url = shotgun_globals.get_entity_type_icon_url(value["type"])

--- a/python/shotgun_fields/file_link_widget.py
+++ b/python/shotgun_fields/file_link_widget.py
@@ -302,7 +302,7 @@ class FileLinkWidget(ElidedLabelBaseWidget):
         :type value: A dictionary as returned by the Shotgun API for a url field
         """
 
-        link_color = sgtk.constants.SG_STYLESHEET_CONSTANTS["SG_HIGHLIGHT_COLOR"]
+        link_color = sgtk.platform.current_bundle().style_constants["SG_HIGHLIGHT_COLOR"]
 
         if value["link_type"] in ["web", "upload"]:
             url = value["url"]
@@ -417,7 +417,7 @@ class _EditWebLinkDialog(QtGui.QDialog):
             self._display_input.selectAll()
 
         # get the highlight color
-        btn_color = sgtk.constants.SG_STYLESHEET_CONSTANTS["SG_HIGHLIGHT_COLOR"]
+        btn_color = sgtk.platform.current_bundle().style_constants["SG_HIGHLIGHT_COLOR"]
         btn_palette = self.palette()
         btn_palette.setColor(QtGui.QPalette.Button, btn_color)
 

--- a/python/shotgun_fields/image_widget.py
+++ b/python/shotgun_fields/image_widget.py
@@ -310,7 +310,7 @@ class ImageWidget(QtGui.QLabel):
         """
         if not self._pixmap:
             if self._editable:
-                link_color = sgtk.constants.SG_STYLESHEET_CONSTANTS["SG_HIGHLIGHT_COLOR"]
+                link_color = sgtk.platform.current_bundle().style_constants["SG_HIGHLIGHT_COLOR"]
                 self.setText(
                     "<a href='image::upload'><font color='%s'>Upload Image"
                     "</font></a>" % (link_color,)

--- a/python/shotgun_fields/url_template_widget.py
+++ b/python/shotgun_fields/url_template_widget.py
@@ -26,6 +26,6 @@ class UrlTemplateWidget(ElidedLabelBaseWidget):
 
         :param str value: The url value to convert into a string
         """
-        link_color = sgtk.constants.SG_STYLESHEET_CONSTANTS["SG_HIGHLIGHT_COLOR"]
+        link_color = sgtk.platform.current_bundle().style_constants["SG_HIGHLIGHT_COLOR"]
         return "<a href='%s'><font color='%s'>%s</font></a>" % (
             value, link_color, value)


### PR DESCRIPTION
This allows for a pre-submit callback to be attached to a NoteInputWidget. This can be used to do things like procedurally add attachments to the NoteInputWidget prior to the Note's or Reply's creation.