### PR TITLE
#36884: Signals passed up for note arrival and entity loading.

### DIFF
--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -22,6 +22,7 @@ from .widget_value_update import ValueUpdateWidget
 from .dialog_reply import ReplyDialog
 from .data_manager import ActivityStreamDataHandler
 from .overlaywidget import SmallOverlayWidget
+from ..note_input_widget import NoteInputDialog
  
 class ActivityStreamWidget(QtGui.QWidget):
     """
@@ -387,6 +388,25 @@ class ActivityStreamWidget(QtGui.QWidget):
         self._data_manager.rescan()
         self._bundle.log_debug("...done")
 
+    def show_new_note_dialog(self, modal=True):
+        """
+        Shows a dialog that allows the user to input a new note.
+
+        :param modal:   Whether the dialog should be shown modally or not.
+        :type modal:    bool
+        """
+        note_dialog = NoteInputDialog(parent=self)
+        note_dialog.entity_created.connect(self._on_entity_created)
+        note_dialog.data_updated.connect(self.rescan)
+        note_dialog.set_bg_task_manager(self._task_manager)
+        note_dialog.set_current_entity(self._entity_type, self._entity_id)
+
+        if modal:
+            note_dialog.exec_()
+        else:
+            note_dialog.show()
+
+
     def rescan(self, force_activity_stream_update=False):
         """
         Triggers a rescan of the current activity stream data.
@@ -689,6 +709,8 @@ class ActivityStreamWidget(QtGui.QWidget):
                 self._data_manager.request_user_thumbnail(reply_user["type"], 
                                                           reply_user["id"], 
                                                           reply_user["image"])
+
+            widget.set_selected(True)
         self.note_arrived.emit(note_id)
 
     def _on_entity_created(self, entity):

--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -150,6 +150,21 @@ class ActivityStreamWidget(QtGui.QWidget):
         """
         The currently loaded note threads, keyed by Note entity id and
         containing a list of Shotgun entity dictionaries.
+
+        Example structure containing a single Note entity:
+            6038: [
+                {
+                    'content': 'This is a test note.',
+                    'created_by': {
+                        'id': 39,
+                        'name': 'Jeff Beeland',
+                        'type': 'HumanUser'
+                    },
+                    'id': 6038,
+                    'sg_metadata': None,
+                    'type': 'Note'
+                }
+            ]
         """
         return self._data_manager.note_threads
 

--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -47,6 +47,7 @@ class ActivityStreamWidget(QtGui.QWidget):
     # The int is the Note entity id that was selected or deselected.
     note_selected = QtCore.Signal(int)
     note_deselected = QtCore.Signal(int)
+    note_arrived = QtCore.Signal(int)
 
     # Emitted when a Note or Reply entity is created. The
     # entity type as a string and id as an int will be
@@ -668,6 +669,7 @@ class ActivityStreamWidget(QtGui.QWidget):
                 self._data_manager.request_user_thumbnail(reply_user["type"], 
                                                           reply_user["id"], 
                                                           reply_user["image"])
+        self.note_arrived.emit(note_id)
 
     def _on_entity_created(self, entity):
         """

--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -146,6 +146,14 @@ class ActivityStreamWidget(QtGui.QWidget):
     # properties
 
     @property
+    def note_threads(self):
+        """
+        The currently loaded note threads, keyed by Note entity id and
+        containing a list of Shotgun entity dictionaries.
+        """
+        return self._data_manager.note_threads
+
+    @property
     def note_widget(self):
         """
         Returns the :class:`~note_input_widget.NoteInputWidget` contained within
@@ -166,8 +174,7 @@ class ActivityStreamWidget(QtGui.QWidget):
         self._allow_screenshots = bool(state)
         self.ui.note_widget.allow_screenshots(self._allow_screenshots)
 
-    allow_screenshots = QtCore.Property(
-        bool,
+    allow_screenshots = property(
         _get_allow_screenshots,
         _set_allow_screenshots,
     )
@@ -186,8 +193,7 @@ class ActivityStreamWidget(QtGui.QWidget):
         """
         self._show_sg_stream_button = bool(state)
 
-    show_sg_stream_button = QtCore.Property(
-        bool,
+    show_sg_stream_button = property(
         _get_show_sg_stream_button,
         _set_show_sg_stream_button,
     )
@@ -204,8 +210,7 @@ class ActivityStreamWidget(QtGui.QWidget):
     def _set_version_items_playable(self, state):
         self._version_items_playable = bool(state)
 
-    version_items_playable = QtCore.Property(
-        bool,
+    version_items_playable = property(
         _get_version_items_playable,
         _set_version_items_playable,
     )

--- a/python/activity_stream/data_manager.py
+++ b/python/activity_stream/data_manager.py
@@ -122,6 +122,21 @@ class ActivityStreamDataHandler(QtCore.QObject):
     def note_threads(self):
         """
         The list of currently-loaded note threads, keyed by Note entity id.
+
+        Example structure containing a single Note entity:
+            6038: [
+                {
+                    'content': 'This is a test note.',
+                    'created_by': {
+                        'id': 39,
+                        'name': 'Jeff Beeland',
+                        'type': 'HumanUser'
+                    },
+                    'id': 6038,
+                    'sg_metadata': None,
+                    'type': 'Note'
+                }
+            ]
         """
         return self._note_threads
         

--- a/python/activity_stream/data_manager.py
+++ b/python/activity_stream/data_manager.py
@@ -86,6 +86,7 @@ class ActivityStreamDataHandler(QtCore.QObject):
     
     update_arrived = QtCore.Signal(list)
     note_arrived = QtCore.Signal(int, int)
+    note_thread_arrived = QtCore.Signal(int, object)
     thumbnail_arrived = QtCore.Signal(dict)
     
     def __init__(self, parent):
@@ -116,6 +117,13 @@ class ActivityStreamDataHandler(QtCore.QObject):
                 
         # set up defaults
         self.__reset()
+
+    @property
+    def note_threads(self):
+        """
+        The list of currently-loaded note threads, keyed by Note entity id.
+        """
+        return self._note_threads
         
     def set_bg_task_manager(self, task_manager):
         """
@@ -181,7 +189,8 @@ class ActivityStreamDataHandler(QtCore.QObject):
         # load note thread only
         note_data = self.__get_note_thread_data(note_id)
         if note_data:
-            self._note_threads[note_id] = note_data        
+            self._note_threads[note_id] = note_data
+            self.note_thread_arrived.emit(note_id, note_data)
 
 
     def load_activity_data(self, entity_type, entity_id, limit=200):

--- a/python/note_input_widget/__init__.py
+++ b/python/note_input_widget/__init__.py
@@ -10,4 +10,5 @@
 
 
 from .widget import NoteInputWidget
+from .dialog import NoteInputDialog
 

--- a/python/note_input_widget/dialog.py
+++ b/python/note_input_widget/dialog.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from sgtk.platform.qt import QtCore, QtGui
+from . import NoteInputWidget
+
+class NoteInputDialog(QtGui.QDialog):
+    """
+    A dialog wrapper for the :class:`NoteInputWidget` widget.
+    """
+    def __init__(self, *args, **kwargs):
+        """
+        Constructor.
+        """
+        super(NoteInputDialog, self).__init__(*args, **kwargs)
+
+        self.setWindowFlags(self.windowFlags() | QtCore.Qt.FramelessWindowHint)
+
+        self.widget = NoteInputWidget(None)
+        self.layout = QtGui.QVBoxLayout()
+        self.layout.setContentsMargins(3,3,3,3)
+        self.layout.addWidget(QtGui.QLabel("Please enter a new note:"))
+        self.layout.addWidget(self.widget)
+        self.setLayout(self.layout)
+
+        self.widget.entity_created.connect(self.accept)
+        self.widget.close_clicked.connect(self.reject)
+
+        self.widget.open_editor()
+
+    def __getattr__(self, name):
+        return getattr(self.widget, name)

--- a/python/version_details/version_details.py
+++ b/python/version_details/version_details.py
@@ -60,6 +60,9 @@ class VersionDetailsWidget(QtGui.QWidget):
     # along.
     entity_created = QtCore.Signal(object)
 
+    # Emitted when an entity is loaded in the panel.
+    entity_loaded = QtCore.Signal(object)
+
     # The int is the id of the Note entity that was selected or deselected.
     note_selected = QtCore.Signal(int)
     note_deselected = QtCore.Signal(int)
@@ -261,6 +264,14 @@ class VersionDetailsWidget(QtGui.QWidget):
         """
         return self._pinned
 
+    @property
+    def note_threads(self):
+        """
+        The currently loaded Note threads keyed by Note entity id and
+        containing a list of Shotgun entity dictionaries.
+        """
+        return self.ui.note_stream_widget.note_threads
+
     ##########################################################################
     # public methods
 
@@ -381,6 +392,8 @@ class VersionDetailsWidget(QtGui.QWidget):
             filters=shot_filters,
             fields=self._fields,
         )
+
+        self.entity_loaded.emit(entity)
 
     def save_preferences(self):
         """

--- a/python/version_details/version_details.py
+++ b/python/version_details/version_details.py
@@ -63,6 +63,7 @@ class VersionDetailsWidget(QtGui.QWidget):
     # The int is the id of the Note entity that was selected or deselected.
     note_selected = QtCore.Signal(int)
     note_deselected = QtCore.Signal(int)
+    note_arrived = QtCore.Signal(int)
 
     def __init__(self, bg_task_manager, parent=None, entity=None):
         """
@@ -212,6 +213,7 @@ class VersionDetailsWidget(QtGui.QWidget):
         self._task_manager.task_completed.connect(self._on_task_completed)
         self.ui.note_stream_widget.note_selected.connect(self.note_selected.emit)
         self.ui.note_stream_widget.note_deselected.connect(self.note_deselected.emit)
+        self.ui.note_stream_widget.note_arrived.connect(self.note_arrived.emit)
 
         # We're taking over the responsibility of handling the title bar's
         # typical responsibilities of closing the dock and managing float

--- a/python/version_details/version_details.py
+++ b/python/version_details/version_details.py
@@ -269,6 +269,21 @@ class VersionDetailsWidget(QtGui.QWidget):
         """
         The currently loaded Note threads keyed by Note entity id and
         containing a list of Shotgun entity dictionaries.
+
+        Example structure containing a single Note entity:
+            6038: [
+                {
+                    'content': 'This is a test note.',
+                    'created_by': {
+                        'id': 39,
+                        'name': 'Jeff Beeland',
+                        'type': 'HumanUser'
+                    },
+                    'id': 6038,
+                    'sg_metadata': None,
+                    'type': 'Note'
+                }
+            ]
         """
         return self.ui.note_stream_widget.note_threads
 

--- a/python/version_details/version_details.py
+++ b/python/version_details/version_details.py
@@ -520,6 +520,15 @@ class VersionDetailsWidget(QtGui.QWidget):
             if self._requested_entity:
                 self.load_data(self._requested_entity)
 
+    def show_new_note_dialog(self, modal=True):
+        """
+        Shows a dialog that allows the user to input a new note.
+
+        :param modal:   Whether the dialog should be shown modally or not.
+        :type modal:    bool
+        """
+        self.ui.note_stream_widget.show_new_note_dialog(modal=modal)
+
     def show_title_bar_buttons(self, state):
         """
         Sets the visibility of the undock and close buttons in the


### PR DESCRIPTION
Plus access to note thread data as a property of activity stream and version details widgets.