### PR TITLE
#36578 Adds ability to register widgets for specific entity/type

### DIFF
--- a/python/shotgun_fields/__init__.py
+++ b/python/shotgun_fields/__init__.py
@@ -9,3 +9,4 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from .shotgun_field_manager import ShotgunFieldManager
+from .shotgun_field_meta import ShotgunFieldMeta

--- a/python/shotgun_fields/shotgun_field_delegate.py
+++ b/python/shotgun_fields/shotgun_field_delegate.py
@@ -105,14 +105,13 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
         """
         self.setEditorData(widget, model_index)
 
-    def setEditorData(self, widget, index):
-        value = index.data(shotgun_model.ShotgunModel.SG_ASSOCIATED_FIELD_ROLE)
-        sanitized_value = shotgun_model.sanitize_qt(value)
-        widget.set_value(sanitized_value)
+    #def setEditorData(self, widget, index):
+    #    value = index.data(shotgun_model.ShotgunModel.SG_ASSOCIATED_FIELD_ROLE)
+    #    sanitized_value = shotgun_model.sanitize_qt(value)
+    #    widget.set_value(sanitized_value)
 
     def setModelData(self, editor, model, index):
         return editor.get_value()
 
-    def editorEvent(self, event, model, option, index):
-        print "EDITOR EVENT: %s" % event
-        return True
+    #def editorEvent(self, event, model, option, index):
+    #    return True


### PR DESCRIPTION
Adds a method to the fields manager: ``register_entity_field_class(cls, entity_type, field_name, widget_class, widget_type)``

Similar to the ``register_class`` method, but registers a widget to be use with a specific entity type and field. This is provided to allow very specific widget customizations for displaying and editing fields when the default widgets are insufficient.

Example usage includes ``checkbox`` fields (boolean values) where you may want to display an icon (or not) based on the field value rather than a standard ``QtGui.QCheckbox`` based widget.

Example:

```python
self._fields_manager.register_entity_field_class(ENTITY_TYPE, "sg_checkbox_field", MyCustomCheckBoxDisplayWidget, self._fields_manager.DISPLAY)
```
