### PR TITLE
#36758 Allows entity+field registration via class member for consistency.

### DIFF
--- a/python/shotgun_fields/shotgun_field_meta.py
+++ b/python/shotgun_fields/shotgun_field_meta.py
@@ -164,8 +164,6 @@ class ShotgunFieldMeta(type(QtGui.QWidget)):
         # create the class instance itself
         field_class = super(ShotgunFieldMeta, mcl).__new__(mcl, name, parents, class_dict)
 
-        # XXX update docs in manager to show how to override entity/field/type
-
         # widgets can be used for multiple reasons (display, edit, editable, etc).
         # build a list of the different types for later registration.
         registration_types = []


### PR DESCRIPTION
Allows a class to be registered for specific entity fields via class members. This feels more in line with how the global widget classes are registered and prevents clients from having to manually register the classes. Here's an example of how this registration is used:

```python
class CheckBoxDisplayWidget(QtGui.QLabel):
    """
    Displays a ``checkbox`` field value as returned by the Shotgun API.
    """
    __metaclass__ = shotgun_fields.ShotgunFieldMeta
    _DISPLAY_TYPE = "checkbox"
    _ENTITY_FIELDS = [
        ("CustomEntity11", "sg_checkbox_field"),
    ]
    # ...
```

This will register a ``checkbox`` display widget that will only be used to display the ``sg_checkbox_field`` for ``CustomEntity11`` entities. 

Also updated meta class docs to show how this feature is used.