### PR TITLE
#35963 Allows editor widgets to be used as delegates with the shotgunmodel

### DIFF
--- a/python/shotgun_fields/file_link_widget.py
+++ b/python/shotgun_fields/file_link_widget.py
@@ -76,8 +76,12 @@ class FileLinkWidget(ElidedLabelBaseWidget):
         self._popup_btn = QtGui.QPushButton(self)
         self._popup_btn.setIcon(QtGui.QIcon(":/qtwidgets-shotgun-fields/link_menu.png"))
         self._popup_btn.setFixedSize(QtCore.QSize(18, 12))
-        self._popup_btn.setFocusPolicy(QtCore.Qt.NoFocus)
         self._popup_btn.hide()
+
+        if not self._delegate:
+            # not sure why, but when the widget is being used in a delegate,
+            # this causes editor to close immediately when clicked.
+            self._popup_btn.setFocusPolicy(QtCore.Qt.NoFocus)
 
         # make sure there's never a bg color or border
         self._popup_btn.setStyleSheet("background-color: none; border: none;")

--- a/python/shotgun_fields/label_base_widget.py
+++ b/python/shotgun_fields/label_base_widget.py
@@ -75,6 +75,7 @@ class ElidedLabelBaseWidget(elided_label.ElidedLabel):
         Display the default value of the widget.
         """
         self.clear()
+        self.setText("")
 
     def _display_value(self, value):
         """

--- a/python/shotgun_fields/shotgun_field_delegate.py
+++ b/python/shotgun_fields/shotgun_field_delegate.py
@@ -12,8 +12,8 @@ import sgtk
 from sgtk.platform.qt import QtCore, QtGui
 
 views = sgtk.platform.current_bundle().import_module("views")
+shotgun_globals = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_globals")
 shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
-
 
 class ShotgunFieldDelegate(views.WidgetDelegate):
     """
@@ -46,13 +46,30 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
         self._editor_class = editor_class
         self._bg_task_manager = bg_task_manager
 
+    def paint(self, painter, style_options, model_index):
+        """
+        Paint method to handle all cells that are not being currently edited.
+
+        :param painter:         The painter instance to use when painting
+        :param style_options:   The style options to use when painting
+        :param model_index:     The index in the data model that needs to be painted
+        """
+
+        # let the base class do all the heavy lifting
+        super(ShotgunFieldDelegate, self).paint(painter, style_options, model_index)
+
+        # clear out the paint widget's contents to prevent it from showing in
+        # other places in the view (since the widget is shared)
+        widget = self._get_painter_widget(model_index, self.view)
+        widget.set_value(None)
+
     def _create_widget(self, parent):
         """
-        :param parent:  QWidget to parent the widget to
-        :type parent:   :class:`~PySide.QtGui.QWidget`
+        :param parent: QWidget to parent the widget to
+        :type parent: :class:`~PySide.QtGui.QWidget`
 
-        :returns:       QWidget that will be used to paint grid cells in the view.
-        :rtype:         :class:`~PySide.QtGui.QWidget`
+        :returns: QWidget that will be used to paint grid cells in the view.
+        :rtype: :class:`~PySide.QtGui.QWidget`
         """
         widget = self._display_class(
             parent=parent,
@@ -61,6 +78,12 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
             bg_task_manager=self._bg_task_manager,
             delegate=True,
         )
+
+        if self._display_class == self._editor_class:
+            # display and edit classes are the same. we need to make sure
+            # we disable the editing
+            widget.enable_editing(False)
+
         return widget
 
     def sizeHint(self, style_options, model_index):
@@ -79,18 +102,22 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
 
     def _create_editor_widget(self, model_index, style_options, parent):
         """
-        :param model_index:     The index of the item in the model to return a widget for
-        :type model_index:      :class:`~PySide.QtCore.QModelIndex`
+        :param model_index: The index of the item in the model to return a widget for
+        :type model_index: :class:`~PySide.QtCore.QModelIndex`
 
-        :param style_options:   Specifies the current Qt style options for this index
-        :type style_options:    :class:`~PySide.QtGui.QStyleOptionViewItem`
+        :param style_options: Specifies the current Qt style options for this index
+        :type style_options: :class:`~PySide.QtGui.QStyleOptionViewItem`
 
-        :param parent:          The parent view that the widget should be parented to
-        :type parent:           :class:`~PySide.QtGui.QWidget`
+        :param parent: The parent view that the widget should be parented to
+        :type parent: :class:`~PySide.QtGui.QWidget`
 
-        :returns:               A QWidget to be used for editing the current index
-        :rtype:                 :class:`~PySide.QtGui.QWidget`
+        :returns: A QWidget to be used for editing the current index
+        :rtype: :class:`~PySide.QtGui.QWidget`
         """
+        # ensure the field is editable
+        if not shotgun_globals.field_is_editable(self._entity_type, self._field_name):
+            return None
+
         if not model_index.isValid():
             return None
 
@@ -104,6 +131,16 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
             bg_task_manager=self._bg_task_manager,
             delegate=True,
         )
+
+        if self._display_class == self._editor_class:
+            # display and edit classes are the same. we need to make sure
+            # we enable the editing
+            widget.enable_editing(True)
+
+        # auto fill the background color so that the display widget doesn't show
+        # behind.
+        widget.setAutoFillBackground(True)
+
         return widget
 
     def _on_before_paint(self, widget, model_index, style_options):
@@ -112,61 +149,196 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
         SG_ASSOCIATED_FIELD_ROLE role.
 
         :param widget: The QWidget (constructed in _create_widget()) which will
-                       be used to paint the cell.
-        :type parent:  :class:`~PySide.QtGui.QWidget`
+            be used to paint the cell.
+        :type parent: :class:`~PySide.QtGui.QWidget`
 
         :param model_index: object representing the data of the object that is
-                            about to be drawn.
-        :type model_index:  :class:`~PySide.QtCore.QModelIndex`
+            about to be drawn.
+        :type model_index: :class:`~PySide.QtCore.QModelIndex`
 
         :param style_options: Object containing specifics about the
-                              view related state of the cell.
-        :type style_options:  :class:`~PySide.QtGui.QStyleOptionViewItem`
+            view related state of the cell.
+        :type style_options: :class:`~PySide.QtGui.QStyleOptionViewItem`
         """
 
-    #def setEditorData(self, widget, index):
-    #    value = index.data(shotgun_model.ShotgunModel.SG_ASSOCIATED_FIELD_ROLE)
-    #    sanitized_value = shotgun_model.sanitize_qt(value)
-    #    widget.set_value(sanitized_value)
+        # make sure the display widget is populated with the correct data
+        _set_widget_value(widget, model_index)
+
+    def setEditorData(self, editor, model_index):
+        """
+        Sets the data to be displayed and edited by the editor from the data
+        model item specified by the model index.
+
+        :param editor: The editor widget.
+        :type editor: :class:`~PySide.QtGui.QWidget`
+        :param model_index: The index of the model to be edited.
+        :type model_index: :class:`~PySide.QtCore.QModelIndex`
+        """
+
+        # make sure the editor widget is populated with the correct data
+        _set_widget_value(editor, model_index)
 
     def setModelData(self, editor, model, index):
-        return editor.get_value()
+        """
+        Gets data from the editor widget and stores it in the specified model at the item index.
 
-    #def editorEvent(self, event, model, option, index):
-    #    return True
+        :param editor: The editor widget.
+        :type editor: :class:`~PySide.QtGui.QWidget`
+        :param model: The SG model where the data lives.
+        :type model: :class:`~shotgun_utils.shotgun_model.ShotgunModel`
+        :param index: The index of the model to be edited.
+        :type index: :class:`~PySide.QtCore.QModelIndex`
+        """
+        src_index = _map_to_source(index)
+        if not src_index or not src_index.isValid():
+            # invalide index, do nothing
+            return
 
-def _display_value(widget, model_index):
+        new_value = editor.get_value()
 
-    src_index = map_to_source(model_index)
+        cur_value = src_index.data(shotgun_model.ShotgunModel.SG_ASSOCIATED_FIELD_ROLE)
+        if cur_value == new_value:
+            # value didn't change. nothing to do here.
+            return
+
+        bundle = sgtk.platform.current_bundle()
+
+        # special case for image fields
+        if editor._field_name == "image":
+            primary_item = src_index.model().item(src_index.row(), 0)
+            try:
+                if new_value:
+                    # update the value locally in the model
+                    primary_item.setIcon(QtGui.QIcon(new_value))
+                else:
+                    primary_item.setIcon(QtGui.QIcon())
+            except Exception, e:
+                bundle.log_error("Unable to set icon for widget delegate: %s" % (e,))
+
+            return
+
+        successful = src_index.model().setData(
+            src_index,
+            new_value,
+            shotgun_model.ShotgunModel.SG_ASSOCIATED_FIELD_ROLE,
+        )
+
+        if not successful:
+            bundle.log_error(
+                "Unable to set model data for widget delegate: %s, %s" %
+                (self._entity_type, self._field_name)
+            )
+
+    def editorEvent(self, event, model, option, index):
+        """
+        Handles mouse events on the editor.
+
+        :param event: The event that occurred.
+        :type event: :class:`~PySide.QtCore.QEvent`
+        :param model: The SG model where the data lives.
+        :type model: :class:`~shotgun_utils.shotgun_model.ShotgunModel`
+        :param option: Options for rendering the item.
+        :type option: :class:`~PySide.QtQui.QStyleOptionViewItem`
+        :param index: The index of the model to be edited.
+        :type index: :class:`~PySide.QtCore.QModelIndex`
+
+        :return: ``True``, if the event was handled, ``False`` otherwise.
+        :rtype: ``bool``
+        """
+
+        # Forward mouse clicks to the underlying display widget. This only kicks
+        # in if the editor widget isn't displayed or doesn't process a mouse
+        # event for some reason. If you're having trouble with editors
+        # disappearing, it may be because they can't receive focus or aren't
+        # handling a mouse click.
+        if event.type() == QtCore.QEvent.MouseButtonRelease:
+            self._forward_mouse_event(event, index)
+            return True
+
+        return False
+
+    def _forward_mouse_event(self, mouse_event, index):
+        """
+        Forward the mouse event to the display widget to simulate
+        interacting with the widget. This is necessary since the delegate only
+        paints the widget in the view rather than being and actual widget
+        instance.
+
+        :param mouse_event: The event that occured on the delegate.
+        :type mouse_event: :class:`~PySide.QtCore.QEvent`
+        :param index: The model index that was acted on.
+        :type index: :class:`~PySide.QtCore.QModelIndex`
+        """
+
+        # get the widget used to paint this index, populate it with the
+        # value for this index
+        widget = self._get_painter_widget(index, self.view)
+        _set_widget_value(widget, index)
+
+        item_rect = self.view.visualRect(index)
+
+        # get the rect of the item in the view
+        widget.resize(item_rect.size())
+
+        # move the widget to 0, 0 so we know exactly where it is
+        widget.move(0, 0)
+
+        # map global mouse position to within item_rect
+        view_pos = self.view.viewport().mapFromGlobal(QtGui.QCursor.pos())
+
+        # calculate the offset from the item rect
+        widget_x = view_pos.x() - item_rect.x()
+        widget_y = view_pos.y() - item_rect.y()
+
+        # forward the mouse event to the display widget
+        forward_event = QtGui.QMouseEvent(
+            mouse_event.type(),
+            QtCore.QPoint(widget_x, widget_y),
+            mouse_event.button(),
+            mouse_event.buttons(),
+            mouse_event.modifiers(),
+        )
+        QtGui.QApplication.sendEvent(widget, forward_event)
+
+
+def _set_widget_value(widget, model_index):
+    """
+    Updates the supplied widget with data from the supplied model index.
+
+    :param widget: The widget to set the value for
+    :type parent: :class:`~PySide.QtGui.QWidget`
+    :param model_index: The index of the model where the data comes from
+    :type model_index: :class:`~PySide.QtCore.QModelIndex`
+    """
+
+    src_index = _map_to_source(model_index)
     if not src_index or not src_index.isValid():
-        widget._display_default()
+        # invalide index, do nothing
         return
 
+    # special case for image fields
     if widget._field_name == "image":
         primary_item = src_index.model().item(src_index.row(), 0)
         icon = primary_item.icon()
         if icon:
-            widget._display_value(icon.pixmap(QtCore.QSize(256, 256)))
-            return
+            widget.set_value(icon.pixmap(QtCore.QSize(256, 256)))
 
     value = src_index.data(shotgun_model.ShotgunModel.SG_ASSOCIATED_FIELD_ROLE)
-    sanitized_value = shotgun_model.sanitize_qt(value)
-    if sanitized_value is None:
-        widget._display_default()
-    else:
-        widget._display_value(sanitized_value)
+    widget.set_value(shotgun_model.sanitize_qt(value))
 
-def map_to_source(idx, recursive=True):
+
+def _map_to_source(idx, recursive=True):
     """
     Map the specified index to it's source model.  This can be done recursively to map
     back through a chain of proxy models to the source model at the beginning of the chain
-    :param idx:         The index to map from
-    :param recursive:   If true then the function will recurse up the model chain until it
-                        finds an index belonging to a model that doesn't derive from
-                        QAbstractProxyModel.  If false then it will just return the index
-                        from the imediate parent model.
-    :returns:           QModelIndex in the source model or the first model in the chain that
-                        isn't a proxy model if recursive is True.
+
+    :param idx: The index to map from
+    :param recursive: If true then the function will recurse up the model chain until it
+        finds an index belonging to a model that doesn't derive from QAbstractProxyModel.
+        If false then it will just return the index from the imediate parent model.
+
+    :returns: QModelIndex in the source model or the first model in the chain that
+        isn't a proxy model if recursive is True.
     """
     src_idx = idx
     while src_idx.isValid() and isinstance(src_idx.model(), QtGui.QAbstractProxyModel):

--- a/python/shotgun_fields/shotgun_field_delegate.py
+++ b/python/shotgun_fields/shotgun_field_delegate.py
@@ -81,15 +81,29 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
 
         if self._display_class == self._editor_class:
             # display and edit classes are the same. we need to make sure
-            # we disable the editing
+            # we disable the editing so that the delegate isn't drawn in its
+            # edit state.
             widget.enable_editing(False)
 
         return widget
 
     def sizeHint(self, style_options, model_index):
         """
-        Returns a size hint for the painter widget.
+        Returns the size needed by the delegate to display the item specified by
+        ``model_index``, taking into account the style information provided by
+        ``style_options``.
+
+        Reimplemented from ``QStyledItemDelegate.sizeHint``
+
+        :param style_options: Style information for the item.
+        :type style_options: :class:`~PySide.QtGui.QStyleOptionViewItem`
+        :param model_index: The index of the item to return the size of.
+        :type model_index: :class:`~PySide.QtCore.QModelIndex`
+
+        :returns: size required by the delegate
+        :rtype: :class:`~PySide.QtCore.QSize`
         """
+
         if not model_index.isValid():
             return QtCore.QSize()
 
@@ -102,6 +116,8 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
 
     def _create_editor_widget(self, model_index, style_options, parent):
         """
+        Create an editor widget for the supplied model index.
+
         :param model_index: The index of the item in the model to return a widget for
         :type model_index: :class:`~PySide.QtCore.QModelIndex`
 
@@ -261,7 +277,7 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
         """
         Forward the mouse event to the display widget to simulate
         interacting with the widget. This is necessary since the delegate only
-        paints the widget in the view rather than being and actual widget
+        paints the widget in the view rather than being an actual widget
         instance.
 
         :param mouse_event: The event that occured on the delegate.
@@ -313,7 +329,7 @@ def _set_widget_value(widget, model_index):
 
     src_index = _map_to_source(model_index)
     if not src_index or not src_index.isValid():
-        # invalide index, do nothing
+        # invalid index, do nothing
         return
 
     # special case for image fields

--- a/python/shotgun_fields/shotgun_field_delegate.py
+++ b/python/shotgun_fields/shotgun_field_delegate.py
@@ -262,6 +262,16 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
         :rtype: ``bool``
         """
 
+        # The primary use for this is labels displaying clickable links (entity,
+        # multi-entity, etc). By default, they're painted into the view via the
+        # delegate, so you can't interact with them. There were some suggestions
+        # online how to work around this that seemed really complex. This is a
+        # solution rob suggested which I tried and it seems to work... and is
+        # much simpler! Basically, detect a mouse click (release is all we have
+        # really) in the delegate, populate the underlying widget with the data
+        # from the index, then forward the event to the widget. The result is a
+        # simulation of clicking on the actual widget.
+
         # Forward mouse clicks to the underlying display widget. This only kicks
         # in if the editor widget isn't displayed or doesn't process a mouse
         # event for some reason. If you're having trouble with editors

--- a/python/shotgun_fields/shotgun_field_meta.py
+++ b/python/shotgun_fields/shotgun_field_meta.py
@@ -218,6 +218,8 @@ class ShotgunFieldMeta(type(QtGui.QWidget)):
         :param bg_task_manager: The task manager the widget will use if it needs to run a task
         :type bg_task_manager: :class:`~task_manager.BackgroundTaskManager`
 
+        :param bool delegate: True if the widget field widget is being used as a delegate, False otherwise.
+
         Additionally pass all other keyword args through to the PySide widget constructor for the
         class' superclass.
         """
@@ -294,7 +296,7 @@ class ShotgunFieldMeta(type(QtGui.QWidget)):
         if value is None:
             self._display_default()
         else:
-            self.set_value(value)
+            self._display_value(value)
         self.value_changed.emit()
 
     @staticmethod

--- a/python/shotgun_fields/shotgun_field_meta.py
+++ b/python/shotgun_fields/shotgun_field_meta.py
@@ -199,7 +199,7 @@ class ShotgunFieldMeta(type(QtGui.QWidget)):
 
         return field_class
 
-    def __call__(cls, parent=None, entity_type=None, field_name=None, entity=None, bg_task_manager=None, **kwargs):
+    def __call__(cls, parent=None, entity_type=None, field_name=None, entity=None, bg_task_manager=None, delegate=False, **kwargs):
         """
         Create an instance of the given class.
 
@@ -231,6 +231,7 @@ class ShotgunFieldMeta(type(QtGui.QWidget)):
         instance._field_name = field_name
         instance._bg_task_manager = bg_task_manager
         instance._bundle = sgtk.platform.current_bundle()
+        instance._delegate = delegate
 
         # do any widget setup that is needed
         instance.setup_widget()
@@ -293,7 +294,7 @@ class ShotgunFieldMeta(type(QtGui.QWidget)):
         if value is None:
             self._display_default()
         else:
-            self._display_value(value)
+            self.set_value(value)
         self.value_changed.emit()
 
     @staticmethod

--- a/python/views/shotgun_tableview.py
+++ b/python/views/shotgun_tableview.py
@@ -32,6 +32,12 @@ class ShotgunTableView(QtGui.QTableView):
 
         self.setMouseTracking(True)
 
+        # identify the ways to initiate editing a field
+        self.setEditTriggers(
+            QtGui.QAbstractItemView.DoubleClicked |
+            QtGui.QAbstractItemView.EditKeyPressed
+        )
+
     def setModel(self, model):
         """
         Overrides the base class setModel.  This assumes that the model is a ShotgunModel

--- a/python/views/widget_delegate.py
+++ b/python/views/widget_delegate.py
@@ -85,6 +85,10 @@ class WidgetDelegate(QtGui.QStyledItemDelegate):
         :returns:           A QWidget to be used for painting the current index
         :rtype:             :class:`~PySide.QtGui.QWidget`
         """
+
+        if not model_index.isValid():
+            return None
+
         # the default implementation just uses the internal __paint_widget 
         # (creating it if needed) for backwards compatibility
         if not self.__paint_widget or not self.__paint_widget():
@@ -114,6 +118,10 @@ class WidgetDelegate(QtGui.QStyledItemDelegate):
         """
         # the default implementation just calls _create_widget for backwards
         # compatibility.
+
+        if not model_index.isValid():
+            return None
+
         return self._create_widget(parent)
 
     def _on_before_paint(self, widget, model_index, style_options):

--- a/python/views/widget_delegate.py
+++ b/python/views/widget_delegate.py
@@ -166,11 +166,11 @@ class WidgetDelegate(QtGui.QStyledItemDelegate):
     def createEditor(self, parent_widget, style_options, model_index):
         """
         Subclassed implementation from QStyledItemDelegate which is
-        called when an "editor" is set up - the editor is set up 
+        called when an "editor" is set up - the editor is set up
         via the openPersistentEditor call and is created upon selection
         of an item.
 
-        Normally, for performance, when we draw hundreds of grid cells, 
+        Normally, for performance, when we draw hundreds of grid cells,
         we use the same Qwidget as a brush and simply use it to paint.
 
         For the currently selected cell however, we need to be able to interact
@@ -178,11 +178,11 @@ class WidgetDelegate(QtGui.QStyledItemDelegate):
         to have a real widget for this.
 
         :param parent_widget:   The parent widget to use for the new editor widget
-        
+
         :param style_options:   The style options to use when creating the editor
-        :param model_index:     The index in the data model that will be edited 
+        :param model_index:     The index in the data model that will be edited
                                 using this editor
-        :returns:               An editor widget that will be used to edit this 
+        :returns:               An editor widget that will be used to edit this
                                 index
         """
         # allow derived class to create the editor widget:

--- a/python/views/widget_delegate.py
+++ b/python/views/widget_delegate.py
@@ -87,6 +87,8 @@ class WidgetDelegate(QtGui.QStyledItemDelegate):
         """
 
         if not model_index.isValid():
+            # if the index is invalid, no field widget will be useful for display
+            # or editing.
             return None
 
         # the default implementation just uses the internal __paint_widget 
@@ -120,6 +122,7 @@ class WidgetDelegate(QtGui.QStyledItemDelegate):
         # compatibility.
 
         if not model_index.isValid():
+            # if the index is invalid, no field widget will be useful for editing.
             return None
 
         return self._create_widget(parent)


### PR DESCRIPTION
This change fleshes out the use of field widgets as delegates with a SG model backed view. Changes include:

- editable views (such as sg tree view) can now edit SG model via field widget delegates
- delegates pull data from model to display in editors and update model properly when closed
- clicking on painted display delegate forwards click to underlying "real" widget. this allows urls to be clicked on to view entity/link fields in browser
- field widgets are now aware when they're being used as delegates. this allows them to be a little smarter about how they process data when necessary. 
