### PR TITLE
#37270: Adds the ability to disable the clickable "hand" cursor on user thumbs.

### DIFF
--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -72,6 +72,7 @@ class ActivityStreamWidget(QtGui.QWidget):
         self._allow_screenshots = True
         self._show_sg_stream_button = True
         self._version_items_playable = True
+        self._clickable_user_icons = True
         
         # apply styling
         self._load_stylesheet()
@@ -157,6 +158,30 @@ class ActivityStreamWidget(QtGui.QWidget):
         replies, access can be found via :meth:`ReplyDialog.note_widget`.
         """
         return self.ui.note_widget
+
+    def _get_clickable_user_icons(self):
+        """
+        Whether user icons in the activity stream display as clickable.
+        If True, a pointing hand cursor will be shown when the mouse is
+        hovered over the icons, otherwise the default arrow cursor will be
+        used.
+        """
+        return self._clickable_user_icons
+
+    def _set_clickable_user_icons(self, state):
+        self._clickable_user_icons = bool(state)
+
+        for widget in self._activity_stream_data_widgets.values():
+            if isinstance(widget, NoteWidget):
+                if state:
+                    widget.set_user_thumb_cursor(QtCore.Qt.PointingHandCursor)
+                else:
+                    widget.set_user_thumb_cursor(QtCore.Qt.ArrowCursor)
+
+    clickable_user_icons = property(
+        _get_clickable_user_icons,
+        _set_clickable_user_icons,
+    )
 
     def _get_pre_submit_callback(self):
         """
@@ -571,6 +596,13 @@ class ActivityStreamWidget(QtGui.QWidget):
             widget.set_info(data)
             widget.entity_requested.connect(lambda entity_type, entity_id: self.entity_requested.emit(entity_type, entity_id))
             widget.playback_requested.connect(lambda sg_data: self.playback_requested.emit(sg_data))
+
+        # If we're not wanting the user icons to display as clickable, then
+        # we need to set their cursor to be the default arrow cursor. Otherwise
+        # we don't need to do anything because they default to the clickable
+        # finger-pointing cursor.
+        if not self.clickable_user_icons and isinstance(widget, NoteWidget):
+            widget.set_user_thumb_cursor(QtCore.Qt.ArrowCursor)
                     
         return widget
         

--- a/python/activity_stream/widget_note.py
+++ b/python/activity_stream/widget_note.py
@@ -54,10 +54,32 @@ class NoteWidget(ActivityStreamBaseWidget):
         # self.ui.links.linkActivated.connect(self._entity_request_from_url)
         self.ui.content.linkActivated.connect(self._entity_request_from_url)
         self.ui.header_left.linkActivated.connect(self._entity_request_from_url)    
-        self.ui.user_thumb.entity_requested.connect(lambda entity_type, entity_id: self.entity_requested.emit(entity_type, entity_id))    
+        self.ui.user_thumb.entity_requested.connect(lambda entity_type, entity_id: self.entity_requested.emit(entity_type, entity_id))
+
+    ##############################################################################
+    # properties
+
+    @property
+    def user_thumb(self):
+        """
+        The user thumbnail widget.
+        """
+        return self.ui.user_thumb
 
     ##############################################################################
     # public interface
+
+    def set_user_thumb_cursor(self, cursor):
+        """
+        Sets the cursor displayed when hovering over the user
+        thumbnail.
+
+        :param cursor: The Qt cursor to set.
+        """
+        self.user_thumb.setCursor(cursor)
+
+        for widget in self._reply_widgets:
+            widget.set_user_thumb_cursor(cursor)
     
     def set_info(self, data):
         """
@@ -141,6 +163,8 @@ class NoteWidget(ActivityStreamBaseWidget):
                     current_attachments = []                                
                                                 
                 w = ReplyWidget(self)
+                w.set_user_thumb_cursor(self.user_thumb.cursor())
+
                 self.ui.reply_layout.addWidget(w)
                 w.set_info(item)
                 self._reply_widgets.append(w)

--- a/python/activity_stream/widget_reply.py
+++ b/python/activity_stream/widget_reply.py
@@ -43,7 +43,17 @@ class ReplyWidget(ActivityStreamBaseWidget):
         self.ui.reply.linkActivated.connect(self._entity_request_from_url)
         self.ui.header_left.linkActivated.connect(self._entity_request_from_url)    
         
-        self.ui.user_thumb.entity_requested.connect(lambda entity_type, entity_id: self.entity_requested.emit(entity_type, entity_id))    
+        self.ui.user_thumb.entity_requested.connect(lambda entity_type, entity_id: self.entity_requested.emit(entity_type, entity_id))
+
+    ##############################################################################
+    # properties
+
+    @property
+    def user_thumb(self):
+        """
+        The user thumbnail widget.
+        """
+        return self.ui.user_thumb
 
     ##############################################################################
     # public interface
@@ -58,6 +68,15 @@ class ReplyWidget(ActivityStreamBaseWidget):
             self.ui.user_thumb.setMaximumSize(QtCore.QSize(30, 30))
         else:
             self._bundle.log_warning("Unknown thumb style for reply")
+
+    def set_user_thumb_cursor(self, cursor):
+        """
+        Sets the cursor displayed when hovering over the user
+        thumbnail.
+
+        :param cursor: The Qt cursor to set.
+        """
+        self.user_thumb.setCursor(cursor)
 
     @property
     def note_widget(self):


### PR DESCRIPTION
This is just a new configuration option for the activity stream widget. In the Shotgun Panel this is used to navigate to the User entity associated with the thumbnail, but in other applications of this widget we want to be able to disable that capability.