### PR TITLE
#36274: Adds attachments filtering mechanism and new note autoselection.

### DIFF
--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -379,6 +379,13 @@ class ActivityStreamWidget(QtGui.QWidget):
         """
         If set to a compiled regular expression, attachment file names that match
         will be filtered OUT and NOT shown.
+
+        .. note:: An re.match() is used, which means the regular expression must
+                  match from the start of the attachment file's basename. See Python's
+                  "re" module documentation for Python 2.x for more information and
+                  examples.
+
+        .. example:: To match only ".gif" extensions: re.compile(r"\w+[.]gif$")
         """
         return self._attachments_filter
 

--- a/python/activity_stream/widget_note.py
+++ b/python/activity_stream/widget_note.py
@@ -61,6 +61,7 @@ class NoteWidget(ActivityStreamBaseWidget):
         self._selected = False
         self._attachments = []
         self._show_note_links = True
+        self._attachments_filter = None
 
         # We set a transparent border initially, because we don't want to
         # see the widget "jump" in its size/placement when it is selected
@@ -141,6 +142,18 @@ class NoteWidget(ActivityStreamBaseWidget):
         self._show_note_links = bool(state)
 
     show_note_links = property(_get_show_note_links, _set_show_note_links)
+
+    def _get_attachments_filter(self):
+        """
+        If set to a compiled regular expression, attachment file names that match
+        will be filtered OUT and NOT shown.
+        """
+        return self._attachments_filter
+
+    def _set_attachments_filter(self, regex):
+        self._attachments_filter = regex
+
+    attachments_filter = property(_get_attachments_filter, _set_attachments_filter)
 
     ##############################################################################
     # public interface
@@ -300,7 +313,11 @@ class NoteWidget(ActivityStreamBaseWidget):
         
         """
         curr_attachment_group_widget_id = len(self._attachment_group_widgets)
-        attachment_group = AttachmentGroupWidget(self, attachments)
+        attachment_group = AttachmentGroupWidget(
+            parent=self,
+            attachment_data=attachments,
+            filter_regex=self.attachments_filter,
+        )
         # don't show the ATTACHMENTS header in the activity stream
         attachment_group.show_attachments_label(False)        
 

--- a/python/version_details/version_details.py
+++ b/python/version_details/version_details.py
@@ -117,6 +117,7 @@ class VersionDetailsWidget(QtGui.QWidget):
         self._note_set_metadata_uids = []
         self._attachment_uids = {}
         self._note_fields = [self.NOTE_METADATA_FIELD]
+        self._attachments_filter = None
 
         self.ui = Ui_VersionDetailsWidget() 
         self.ui.setupUi(self)
@@ -335,6 +336,19 @@ class VersionDetailsWidget(QtGui.QWidget):
         """
         return self.ui.note_stream_widget.note_threads
 
+    def _get_attachments_filter(self):
+        """
+        If set to a compiled regular expression, attachment file names that match
+        will be filtered OUT and NOT shown.
+        """
+        return self._attachments_filter
+
+    def _set_attachments_filter(self, regex):
+        self._attachments_filter = regex
+        self.ui.note_stream_widget.attachments_filter = regex
+
+    attachments_filter = property(_get_attachments_filter, _set_attachments_filter)
+
     ##########################################################################
     # public methods
 
@@ -360,6 +374,8 @@ class VersionDetailsWidget(QtGui.QWidget):
                     cleanup_after_upload=cleanup_after_upload,
                 ),
             )
+
+        self.ui.note_stream_widget.rescan(force_activity_stream_update=True)
 
     def add_query_fields(self, fields):
         """

--- a/python/version_details/version_details.py
+++ b/python/version_details/version_details.py
@@ -115,6 +115,7 @@ class VersionDetailsWidget(QtGui.QWidget):
         self._version_context_menu_actions = []
         self._note_metadata_uids = []
         self._note_set_metadata_uids = []
+        self._uploads_uids = []
         self._attachment_uids = {}
         self._note_fields = [self.NOTE_METADATA_FIELD]
         self._attachments_filter = None
@@ -365,7 +366,7 @@ class VersionDetailsWidget(QtGui.QWidget):
             note_entity = note_entity["entity"]
 
         for file_path in file_paths:
-            self._upload_uid = self._data_retriever.execute_method(
+            self._upload_uids.append(self._data_retriever.execute_method(
                 self.__upload_file,
                 dict(
                     file_path=file_path,
@@ -373,9 +374,7 @@ class VersionDetailsWidget(QtGui.QWidget):
                     parent_entity_id=note_entity["id"],
                     cleanup_after_upload=cleanup_after_upload,
                 ),
-            )
-
-        self.ui.note_stream_widget.rescan(force_activity_stream_update=True)
+            ))
 
     def add_query_fields(self, fields):
         """
@@ -671,6 +670,8 @@ class VersionDetailsWidget(QtGui.QWidget):
             note_id = self._attachment_uids[uid]
             del self._attachment_uids[uid]
             self.note_attachment_arrived.emit(note_id, data["file_path"])
+        elif uid in self._upload_uids:
+            self.ui.note_stream_widget.rescan(force_activity_stream_update=True)
 
     def __on_worker_failure(self, uid, msg):
         """


### PR DESCRIPTION
Feature polish for SG3DR. Allows Note attachments to be filtered out of the attachment group widget based on a regex match against the attachment name. Also autoselects newly-created Notes if note selection is activated in the activity stream widget.

Bug fix: forces an sqlite cache update from SG when new attachments to a Note entity are made.