### PR TITLE
#37714 Improved activity stream note creation in site context

### DIFF
--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -427,9 +427,11 @@ class ActivityStreamWidget(QtGui.QWidget):
 
         # if the project context is None, the entity is a non project entity and it's NOT
         # the project entity itself, we don't have access to any project state.
-        no_project_available = self._bundle.context.project is None \
-                               and is_non_project_entity_type \
-                               and self._entity_type != "Project"
+        no_project_available = (
+            self._bundle.context.project is None and
+            is_non_project_entity_type and
+            self._entity_type != "Project"
+        )
 
         # also disable note creation in the case we have a site context
         # and a non-project entity

--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -23,7 +23,9 @@ from .dialog_reply import ReplyDialog
 from .data_manager import ActivityStreamDataHandler
 from .overlaywidget import SmallOverlayWidget
 from ..note_input_widget import NoteInputDialog
- 
+
+shotgun_globals = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_globals")
+
 class ActivityStreamWidget(QtGui.QWidget):
     """
     QT Widget that displays the Shotgun activity stream for an entity.
@@ -418,7 +420,24 @@ class ActivityStreamWidget(QtGui.QWidget):
         # to mimic the behavior in shotgun - which seems quite strange and
         # inconsistent for users, we need to disable to note dialog for 
         # these cases
+
+        # note - this may return [] if shotgun globals aren't yet cached
+        schema_fields = shotgun_globals.get_entity_fields(self._entity_type)
+        is_non_project_entity_type = len(schema_fields) > 0 and "project" not in schema_fields
+
+        # if the project context is None, the entity is a non project entity and it's NOT
+        # the project entity itself, we don't have access to any project state.
+        no_project_available = self._bundle.context.project is None \
+                               and is_non_project_entity_type \
+                               and self._entity_type != "Project"
+
+        # also disable note creation in the case we have a site context
+        # and a non-project entity
         if self._entity_type in ["ApiUser", "HumanUser", "ClientUser"]:
+            self.ui.note_widget.setVisible(False)
+        elif no_project_available:
+            # we don't have any project to hang these notes off, so disable
+            # the note integration
             self.ui.note_widget.setVisible(False)
         else:
             self.ui.note_widget.setVisible(True)

--- a/python/note_input_widget/widget.py
+++ b/python/note_input_widget/widget.py
@@ -341,64 +341,73 @@ class NoteInputWidget(QtGui.QWidget):
 
         :returns:       A Shotgun entity dictionary for the Note that was created.
         """
-        # note - no logging in here, as I am not sure how all 
+        # note - no logging in here, as I am not sure how all
         # engines currently react to log_debug() async.
-        
-        # step 1 - extend out the link dictionary according to specific logic.
-        # - if link is a version, then also include the item the version 
+
+        # There is lots of business logic hard coded into Shotgun
+        # for now, attempt to mimic this logic in this method.
+
+        # Extend out the link dictionary according to specific logic:
+
+        # - if link is a version, then also include the item the version
         #   is linked to and the version's task
-        
-        # - if a link is a task, find its link and use that as the main link. 
+
+        # - if a link is a task, find its link and use that as the main link.
         #   set the task to be linked up to the tasks field.
-        
-        # - if link is a user, group or script then address the note TO 
-        #   that user rather associating the user with the note. 
-        
-        
-        # first establish defaults        
+
+        # - if link is a user, group or script then address the note TO
+        #   that user rather associating the user with the note.
+
+        # - if data["project"] is None (which typically happens when running in a null-context
+        #   environment, attempt to pick up the project from the associated entity.
+
+        # first establish defaults
         project = data["project"]
         addressings_to = data["recipient_links"]
         note_links = []
         note_tasks = []
-        
-        
+
+        # step 1 - business logic for linking
         # now apply specific logic
         entity_link = data["entity"]
-        
-        if entity_link["type"] in ["HumanUser", "ApiUser", "Group"]:            
+        # as we are retrieving data for the associated
+        # entity, also pull down the associated project
+        entity_project_link = None
+
+        if entity_link["type"] in ["HumanUser", "ApiUser", "Group"]:
             # for users, scripts and groups,
             # address the note TO the entity
             addressings_to.append(entity_link)
 
-            # Also link the note to the user. This is to get the 
+            # Also link the note to the user. This is to get the
             # activity stream logic to work.
             # note that because we don't have the display name for the entity,
             # we need to retrieve this
-            sg_entity = sg.find_one(entity_link["type"], 
-                                    [["id", "is", entity_link["id"] ]], 
+            sg_entity = sg.find_one(entity_link["type"],
+                                    [["id", "is", entity_link["id"] ]],
                                     ["cached_display_name"])
-            note_links += [{"id": entity_link["id"], 
-                           "type": entity_link["type"], 
-                           "name": sg_entity["cached_display_name"] }] 
-            
-        
+            note_links += [{"id": entity_link["id"],
+                           "type": entity_link["type"],
+                           "name": sg_entity["cached_display_name"] }]
+
+
         elif entity_link["type"] == "Version":
-            # if we are adding a note to a version, link it with the version 
+            # if we are adding a note to a version, link it with the version
             # and the entity that the version is linked to.
-            # if the version has a task, link the task to the note too.  
-            sg_version = sg.find_one("Version", 
-                                     [["id", "is", entity_link["id"] ]], 
+            # if the version has a task, link the task to the note too.
+            sg_version = sg.find_one("Version",
+                [["id", "is", entity_link["id"] ]],
                                      ["entity", "sg_task", "cached_display_name", "project"])
-            
+
             # first make a std sg link to the current entity - this to ensure we have a name key present
-            note_links += [{"id": entity_link["id"], 
-                            "type": entity_link["type"], 
-                            "name": sg_version["cached_display_name"] }] 
-            
+            note_links += [{"id": entity_link["id"],
+                            "type": entity_link["type"],
+                            "name": sg_version["cached_display_name"] }]
+
             # and now add the linked entity, if there is one
             if sg_version["entity"]:
                 note_links += [sg_version["entity"]]
-            
+
             if sg_version["sg_task"]:
                 note_tasks += [sg_version["sg_task"]]
 
@@ -406,14 +415,14 @@ class NoteInputWidget(QtGui.QWidget):
             # we know we can get it from the Version entity itself.
             if not project and sg_version["project"]:
                 project = sg_version["project"]
-            
+
         elif entity_link["type"] == "Task":
             # if we are adding a note to a task, link the note to the entity that is linked to the
             # task. The link the task to the note via the task link.
-            sg_task = sg.find_one("Task", 
-                                  [["id", "is", entity_link["id"] ]], 
+            sg_task = sg.find_one("Task",
+                [["id", "is", entity_link["id"] ]],
                                   ["entity", "project"])
-            
+
             if sg_task["entity"]:
                 # there is an entity link from this task
                 note_links += [sg_task["entity"]]
@@ -422,24 +431,31 @@ class NoteInputWidget(QtGui.QWidget):
             # can get one from the Task entity.
             if not project and sg_task["project"]:
                 project = sg_task["project"]
-            
-            # lastly, link the note's task link to this task            
+
+            # lastly, link the note's task link to this task
             note_tasks += [entity_link]
-        
+
         else:
             # no special logic. Just link the note to the current entity.
             # note that because we don't have the display name for the entity,
             # we need to retrieve this
-            sg_entity = sg.find_one(entity_link["type"], 
-                                    [["id", "is", entity_link["id"] ]], 
-                                    ["cached_display_name"])
-            note_links += [{"id": entity_link["id"], 
-                           "type": entity_link["type"], 
-                           "name": sg_entity["cached_display_name"] }] 
-        
-        
-        
-        
+            sg_entity = sg.find_one(entity_link["type"],
+                                    [["id", "is", entity_link["id"] ]],
+                                    ["cached_display_name", "project"])
+            note_links += [{"id": entity_link["id"],
+                           "type": entity_link["type"],
+                           "name": sg_entity["cached_display_name"] }]
+
+            # store associated project for use later
+            if entity_link["type"] == "Project":
+                # note on a project
+                entity_project_link = entity_link
+            else:
+                # note - some entity types may not have a project field
+                # so don't assume the key exists.
+                entity_project_link = sg_entity.get("project")
+
+
         # step 2 - generate the subject line. The following
         # convention exists for this:
         #
@@ -456,23 +472,38 @@ class NoteInputWidget(QtGui.QWidget):
                 # for older cores, just split on the first space
                 # Sorry Mary Jane Watson!
                 first_name = current_user.get("name").split(" ")[0]
-                
-            title = "%s's Note" % first_name 
+
+            title = "%s's Note" % first_name
         else:
             title = "Unknown user's Note"
-        
+
         if len(note_links) > 0:
             note_names = [x["name"] for x in note_links]
             title += " on %s" % (", ".join(note_names))
 
+        # step 3 - handle project gracefully
+        if project is None:
+            # attempt to pull it from the entity link
+            if entity_project_link is None:
+                # there is no associated project - likely this is a note
+                # on a non-project entity created in the site ctx
+                raise TankError(
+                    "Cannot determine the project to associate the note with. "
+                    "This usually happens when you submit note on a non-project "
+                    "entity while running Toolkit in a Site context."
+                )
+            else:
+                project = entity_project_link
+
+
         # this is an entity - so create a note and link it
         sg_note_data = sg.create("Note", {"content": data["text"],
-                                          "subject": title, 
+                                          "subject": title,
                                           "project": project,
                                           "addressings_to": addressings_to,
                                           "note_links": note_links,
                                           "tasks": note_tasks })
-        
+
         self.__upload_thumbnail(sg_note_data, sg, data)
         self.__upload_attachments(sg_note_data, sg, data)
 

--- a/python/note_input_widget/widget.py
+++ b/python/note_input_widget/widget.py
@@ -395,9 +395,11 @@ class NoteInputWidget(QtGui.QWidget):
             # if we are adding a note to a version, link it with the version
             # and the entity that the version is linked to.
             # if the version has a task, link the task to the note too.
-            sg_version = sg.find_one("Version",
+            sg_version = sg.find_one(
+                "Version",
                 [["id", "is", entity_link["id"] ]],
-                                     ["entity", "sg_task", "cached_display_name", "project"])
+                ["entity", "sg_task", "cached_display_name", "project"]
+            )
 
             # first make a std sg link to the current entity - this to ensure we have a name key present
             note_links += [{"id": entity_link["id"],
@@ -419,9 +421,11 @@ class NoteInputWidget(QtGui.QWidget):
         elif entity_link["type"] == "Task":
             # if we are adding a note to a task, link the note to the entity that is linked to the
             # task. The link the task to the note via the task link.
-            sg_task = sg.find_one("Task",
-                [["id", "is", entity_link["id"] ]],
-                                  ["entity", "project"])
+            sg_task = sg.find_one(
+                "Task",
+                [["id", "is", entity_link["id"]]],
+                ["entity", "project"]
+            )
 
             if sg_task["entity"]:
                 # there is an entity link from this task


### PR DESCRIPTION
This adds logic to the activity stream widget and note input widget to better handle the state when no project is available in the context (e.g. a "site" context).

Notes that are created require a project to be set and there are some cases when a project isn't available. Normally, we pull the project from the context but in the site context situation this is not an option. Instead, the note creation widget now tries to look for a project on the entity itself and if that fails in errors. The activity stream in turn hides the note input widgets in these cases.
