### PR TITLE
#37784: Maintains a consistent interface between editable and display fields widgets.

### DIFF
--- a/python/shotgun_fields/shotgun_field_editable.py
+++ b/python/shotgun_fields/shotgun_field_editable.py
@@ -98,6 +98,9 @@ class ShotgunFieldEditable(QtGui.QStackedWidget):
 
         self.currentWidget().setFocus()
 
+    def __getattr__(self, name):
+        return getattr(self._display.display_widget, name)
+
 
 class ShotgunFieldNotEditable(QtGui.QWidget):
     """
@@ -151,6 +154,9 @@ class ShotgunFieldNotEditable(QtGui.QWidget):
             self._no_edit_lbl.hide()
 
         return False
+
+    def __getattr__(self, name):
+        return getattr(self._display_widget, name)
 
 
 class _DisplayWidget(QtGui.QWidget):

--- a/python/version_details/shotgun_entities/card_widget.py
+++ b/python/version_details/shotgun_entities/card_widget.py
@@ -289,6 +289,7 @@ class ShotgunEntityCardWidget(QtGui.QWidget):
         # the field widgets into the layout.
         if self.entity:
             self._entity = entity
+            self.thumbnail._needs_download = True
             self.thumbnail.set_value(entity.get("image"))
 
             for field, field_data in self._fields.iteritems():


### PR DESCRIPTION
Makes use of a `__getattr__` to ensure that editable fields widgets provide the same interface as the display widgets that they wrap.