### PR TITLE
#37784 Fixes for entity edit widgets as per QA notes:

### DIFF
--- a/docs/shotgun_fields.rst
+++ b/docs/shotgun_fields.rst
@@ -579,15 +579,10 @@ Example Code
 TODOs & Known Issues
 ====================
 
-- Pressing ``Enter`` or ``Return`` in an entity editor does not always apply the completed value
 - Bubble widget does not display characters properly in some scenarios
 - Timecode & Duration widgets are on hold until python API changes make them feasible
 - Tag edit widget partially done but also awaiting python API edit ability
 - ``ElidedLabel`` causes draw lagging when used in editable widget in Grid/Form layout
-- Global completer with QTextEdit, clicking on popup item does not emit activated (keyboard nav works fine)
 - The note input widget should be updated to use the global completer
 - The status list widget editor should also use colors for visual hint like display widget
-- Retrieving reliable field delegates from the field manager is in progress
-- Editor interaction with the shotgun model is still to come
 - shotgun model to auto update SG on changes still to come
-- shotgun tableview using fields widgets still in progress

--- a/python/global_search_completer/global_search_completer.py
+++ b/python/global_search_completer/global_search_completer.py
@@ -298,7 +298,9 @@ class GlobalSearchCompleter(QtGui.QCompleter):
         Clears the current data in the model.
 
         :param add_loading_item: if true, a "loading please wait" item will
-                                 be added.
+            be added.
+        :param add_more_text_item: if true, a "type at least 3 characers..."
+            item will be added.
         """
         # clear model
         self.model().clear()

--- a/python/global_search_completer/search_result_delegate.py
+++ b/python/global_search_completer/search_result_delegate.py
@@ -74,7 +74,12 @@ class SearchResultDelegate(views.EditSelectedWidgetDelegate):
         if mode == GlobalSearchCompleter.MODE_LOADING:
             widget.set_text("Hold on, loading search results...")
             widget.set_thumbnail(None)
-        
+
+        elif mode == GlobalSearchCompleter.MODE_NOT_ENOUGH_TEXT:
+            widget.set_text("Type at least %s characters..." % (
+                GlobalSearchCompleter.COMPLETE_MINIMUM_CHARACTERS,))
+            widget.set_thumbnail(None)
+
         elif mode == GlobalSearchCompleter.MODE_NOT_FOUND:
             widget.set_text("Sorry, no matches found!")
             widget.set_thumbnail(None)

--- a/python/global_search_widget/global_search_widget.py
+++ b/python/global_search_widget/global_search_widget.py
@@ -25,6 +25,7 @@ class GlobalSearchWidget(QtGui.QLineEdit):
 
     # emitted when shotgun has been updated
     entity_selected = QtCore.Signal(str, int)
+    entity_activated = QtCore.Signal(str, int, str)
 
     def __init__(self, parent):
         """
@@ -46,9 +47,11 @@ class GlobalSearchWidget(QtGui.QLineEdit):
         # trigger the completer to popup as text changes
         self.textEdited.connect(self.completer().search)
 
-        # forward the completer's selected signal
+        # forward the completer's activated/selected signals
         self.completer().entity_selected.connect(self.entity_selected.emit)
-        
+        self.completer().entity_activated.connect(self.entity_activated.emit)
+
+
     def set_bg_task_manager(self, task_manager):
         """
         Specify the background task manager to use to pull

--- a/python/global_search_widget/global_search_widget.py
+++ b/python/global_search_widget/global_search_widget.py
@@ -21,6 +21,10 @@ class GlobalSearchWidget(QtGui.QLineEdit):
     
     :signal: ``entity_selected(str, int)`` - Fires when someone selects an entity inside
             the search results. The returned parameters are entity type and entity id.
+
+    :signal: ``entity_activated(str, int, str)`` - Fires when someone selects an
+        entity inside the search results. Similar to ``entity_selected``, with
+        the addition of the ``name`` of the activated entity being supplied.
     """
 
     # emitted when shotgun has been updated

--- a/python/shotgun_fields/bubble_widget.py
+++ b/python/shotgun_fields/bubble_widget.py
@@ -248,6 +248,7 @@ class BubbleEditWidget(QtGui.QTextEdit):
         :type object: :class:`~PySide.QtCore.Qt.QEvent`
         :return: True'' if the event was filtered, ''False'' otherwise.
         """
+
         if not isinstance(event, QtGui.QMouseEvent):
             # only pass on mouse events
             return False
@@ -280,6 +281,7 @@ class BubbleEditWidget(QtGui.QTextEdit):
             child_widget = bubble.childAt(bubble_pos)
             if isinstance(child_widget, QtGui.QPushButton):
                 child_widget.click()
+            return True
 
         return False
 

--- a/python/shotgun_fields/entity_widget.py
+++ b/python/shotgun_fields/entity_widget.py
@@ -76,7 +76,6 @@ class EntityEditorWidget(global_search_widget.GlobalSearchWidget):
     """
     __metaclass__ = ShotgunFieldMeta
     _EDITOR_TYPE = "entity"
-    _IMMEDIATE_APPLY = True
 
     def setup_widget(self):
         """
@@ -103,7 +102,44 @@ class EntityEditorWidget(global_search_widget.GlobalSearchWidget):
 
         self.set_searchable_entity_types(valid_types)
 
-        self.completer().entity_activated.connect(self._on_entity_activated)
+        self.entity_activated.connect(self._on_entity_activated)
+
+    def get_value(self):
+        """
+        Returns the current valid value for this widget.
+        """
+
+        if self.isVisible() and not self.text():
+            # text was cleared out. return None
+            # TODO: not sure this is the right approach
+            return None
+
+        # return the stored value. if they've typed something else,
+        # we can't ensure it's a valid entity. this implies requiring the use
+        # of the completer.
+        return self._value
+
+    def keyPressEvent(self, event):
+        """
+        Provides shortcuts for applying modified values.
+
+        :param event: The key press event object
+        :type event: :class:`~PySide.QtGui.QKeyEvent`
+
+        Ctrl+Enter or Ctrl+Return will trigger the emission of the ``value_changed``
+        signal.
+        """
+        if event.key() in [
+            QtCore.Qt.Key_Enter,
+            QtCore.Qt.Key_Return
+        ] and event.modifiers() & QtCore.Qt.ControlModifier:
+            if not self.text():
+                self._value = None
+                self.value_changed.emit()
+                event.ignore()
+            return
+
+        super(EntityEditorWidget, self).keyPressEvent(event)
 
     def _begin_edit(self):
         """

--- a/python/shotgun_fields/multi_entity_widget.py
+++ b/python/shotgun_fields/multi_entity_widget.py
@@ -105,7 +105,8 @@ class MultiEntityEditorWidget(BubbleEditWidget):
         # http://doc.qt.io/qt-4.8/qt-tools-customcompleter-example.html
         self._completer.setWidget(self)
 
-        self._show_completer()
+        if not self._completer.popup().isVisible():
+            self._show_completer()
         super(MultiEntityEditorWidget, self).focusInEvent(event)
 
     def get_value(self):
@@ -151,6 +152,10 @@ class MultiEntityEditorWidget(BubbleEditWidget):
             QtCore.Qt.Key_Tab,
         ]:
             entity_dict = self._completer.get_current_result()
+            if not entity_dict:
+                # nothing current, get the first result
+                entity_dict = self._completer.get_first_result()
+
             if entity_dict:
                 self.add_entity(entity_dict)
                 self.clear_typed_text()
@@ -219,6 +224,7 @@ class MultiEntityEditorWidget(BubbleEditWidget):
         """
         entity_dict = {"type": type, "id": id, "name": name}
         self._completer.popup().hide()
+        self._completer.clear()
         self.clear_typed_text()
         self.add_entity(entity_dict)
 
@@ -235,7 +241,7 @@ class MultiEntityEditorWidget(BubbleEditWidget):
         typed_text = self.get_typed_text()
         if self.isVisible() and typed_text:
             rect = self.cursorRect()
-            rect.setWidth(self.width())
+            rect.setWidth(300)
             rect.moveLeft(self.rect().left())
             rect.moveTop(rect.top() + 6)
             self._completer.setCompletionPrefix(typed_text)

--- a/python/shotgun_fields/shotgun_field_editable.py
+++ b/python/shotgun_fields/shotgun_field_editable.py
@@ -70,6 +70,14 @@ class ShotgunFieldEditable(QtGui.QStackedWidget):
         self._display.display_widget.value_changed.connect(
             self.value_changed.emit)
 
+    def destroy(self):
+        """
+        Call to ensure proper destruction of contained widgets.
+        """
+
+        self._display.display_widget.destroy()
+        self._editor.edit_widget.destroy()
+
     def enable_editing(self, enable):
         """
         For consistency, allow the calling code to enable/disable editing.


### PR DESCRIPTION
* added an item to the completer to indicate that the minimum number of
  characters to get results is 3. will now show "Type at least 3 characters..."
* completer popup will now be wide enough to show the complete results
    * smaller widgets were displaying popup that matched the width of the
      widget itself.
* added a method to manually clear the contents of the completer
* added a method to return the first result in the completer
    * this makes for it quick and easy to add entities to a multi entity widget
    * if no results are selected, the first will be used by hitting tab or enter
    * no more need to navigate to the first item to select it then hit enter
* the search widget now exposes the new entity_activated signal from the
    completer
    * connecting to this directly rather than having a subclass access the
        completer directly seems to address some of the reliability issues
    * not sure why
* minor bug fix to bubble widget
* turned off immediate reply for entity widget
    * this means the apply button (checkmark) is now visible again
    * this was done to facilitate clearing the contents to remove the value
      (which is valid)
* implemented get_value for entity widget
    * this will return None if the text is empty, otherwise the stored value
    * this makes the apply work for clearing the contents
* added key press short cuts for applying the value in the entity widget
    if the text has been cleared
* only show the completer in the multi entity widget focus in if its not
    already visible
    * this fixes the issue that was preventing clicks on popup
* updated "Known Issues" in docs