### PR TITLE
Do not show new note dialog if there is no current entity.

### DIFF
--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -614,8 +614,8 @@ class ActivityStreamWidget(QtGui.QWidget):
         :param bool modal: Whether the dialog should be shown modally or not.
         """
         if self._entity_id == None:
-            self._bundle.log_warning("Skipping New Note Dialog - No entity loaded.")
-            return;
+            self._bundle.log_debug("Skipping New Note Dialog - No entity loaded.")
+            return
 
         note_dialog = NoteInputDialog(parent=self)
         note_dialog.entity_created.connect(self._on_entity_created)

--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -613,6 +613,10 @@ class ActivityStreamWidget(QtGui.QWidget):
 
         :param bool modal: Whether the dialog should be shown modally or not.
         """
+        if self._entity_id == None:
+            self._bundle.log_warning("Skipping New Note Dialog - No entity loaded.")
+            return;
+
         note_dialog = NoteInputDialog(parent=self)
         note_dialog.entity_created.connect(self._on_entity_created)
         note_dialog.data_updated.connect(self.rescan)


### PR DESCRIPTION
https://jira.autodesk.com/browse/GAME-17158

In Dynamite, if the user started drawing with no version loaded, the new note panel was showing. It should only show if there is a version loaded to add a note to. This change early outs if that is the case.