### PR TITLE
#38326 Removes project-only workarounds for completer in entity/multi-entity fields

### DIFF
--- a/python/global_search_completer/global_search_completer.py
+++ b/python/global_search_completer/global_search_completer.py
@@ -341,7 +341,12 @@ class GlobalSearchCompleter(QtGui.QCompleter):
 
         # constrain by project in the search
         project_ids = []
-        if self._bundle.context.project:
+
+        if len(self._entity_search_criteria.keys()) == 1 and \
+           "Project" in self._entity_search_criteria:
+            # this is a Project-only search. don't restrict by the current project id
+            pass
+        elif self._bundle.context.project:
             project_ids.append(self._bundle.context.project["id"])
 
         # run the query

--- a/python/shotgun_fields/entity_widget.py
+++ b/python/shotgun_fields/entity_widget.py
@@ -13,6 +13,7 @@ from sgtk.platform.qt import QtCore, QtGui
 
 from .label_base_widget import ElidedLabelBaseWidget
 from .shotgun_field_meta import ShotgunFieldMeta
+from .util import check_project_search_supported
 
 shotgun_globals = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_globals")
 global_search_widget = sgtk.platform.current_bundle().import_module("global_search_widget")
@@ -84,6 +85,12 @@ class EntityEditorWidget(global_search_widget.GlobalSearchWidget):
         Called by the metaclass during initialization. Sets the bg task manager
         for the completer and sets the entity type(s) to be searched.
         """
+
+        sg_connection = self._bundle.sgtk.shotgun
+
+        # TODO: remove this check and backward compatibility layer. added 09/16
+        self._project_search_supported = check_project_search_supported(sg_connection)
+
         self.set_bg_task_manager(self._bg_task_manager)
 
         self._types = shotgun_globals.get_valid_types(
@@ -93,7 +100,12 @@ class EntityEditorWidget(global_search_widget.GlobalSearchWidget):
 
         # get this field's schema
         for entity_type in self._types:
-            valid_types[entity_type] = []
+            if entity_type == "Project" and not self._project_search_supported:
+                # there is an issue querying Project entities via text_search
+                # with older versions of SG. for now, don't restrict the editor
+                 continue
+            else:
+                valid_types[entity_type] = []
 
         self.set_searchable_entity_types(valid_types)
 

--- a/python/shotgun_fields/entity_widget.py
+++ b/python/shotgun_fields/entity_widget.py
@@ -93,12 +93,7 @@ class EntityEditorWidget(global_search_widget.GlobalSearchWidget):
 
         # get this field's schema
         for entity_type in self._types:
-            if entity_type == "Project":
-                # there is currently an issue querying Project entities via the
-                # python API's text search. for now, do not restrict the editor.
-                continue
-            else:
-                valid_types[entity_type] = []
+            valid_types[entity_type] = []
 
         self.set_searchable_entity_types(valid_types)
 

--- a/python/shotgun_fields/multi_entity_widget.py
+++ b/python/shotgun_fields/multi_entity_widget.py
@@ -176,11 +176,6 @@ class MultiEntityEditorWidget(BubbleEditWidget):
 
         # get this field's schema
         for entity_type in shotgun_globals.get_valid_types(self._entity_type, self._field_name):
-            # TODO: the python-api does not like doing text search across projects.
-            # This is being addressed in a ticket internally. For now, ignore the
-            # project type.
-            if entity_type == "Project":
-                continue
             valid_types[entity_type] = []
 
         self._completer = global_search_completer.GlobalSearchCompleter()

--- a/python/shotgun_fields/util.py
+++ b/python/shotgun_fields/util.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+
+def check_project_search_supported(sg_connection):
+    """
+    A compatibility check to see if the current version of SG has the fix
+    that allows text_search to be run for projects.
+
+    :returns: ``True`` if project search is possible, ``False`` otherwise.
+
+
+    .. warning::
+
+        This method is not part of the public API. It will be removed without
+        warning in the future.
+    """
+
+    server_caps = sg_connection.server_caps
+
+    # make sure we're greater than or equal to SG v7.0.2
+    return (
+        hasattr(sg_connection, "server_caps") and
+        server_caps.version and
+        server_caps.version >= (7, 0, 2)
+    )


### PR DESCRIPTION
Now allows for project-only search completion with the SG side bug fix. Required adding a special case whereby the completer detects that the query is only for Project entities and does not restrict by the current project. All other scenarios will continue to restrict by the current project if it can be determined.