### PR TITLE
#38223 No duplicate notes in activity stream

### DIFF
--- a/python/activity_stream/widget_note.py
+++ b/python/activity_stream/widget_note.py
@@ -42,7 +42,7 @@ class NoteWidget(ActivityStreamBaseWidget):
     # Note entity ID associated with this widget.
     selection_changed = QtCore.Signal(bool, int)
     
-    def __init__(self, parent):
+    def __init__(self, note_id, parent):
         """
         :param parent: QT parent object
         :type parent: :class:`PySide.QtGui.QWidget`        
@@ -54,7 +54,7 @@ class NoteWidget(ActivityStreamBaseWidget):
         self.ui = Ui_NoteWidget() 
         self.ui.setupUi(self)
         
-        self._note_id = None
+        self._note_id = note_id
         self._general_widgets = []
         self._reply_widgets = []
         self._attachment_group_widgets = {}
@@ -354,7 +354,7 @@ class NoteWidget(ActivityStreamBaseWidget):
         
         return html
         
-        
+
     def set_note_info(self, data):
         """
         update with new note data


### PR DESCRIPTION
Fixes an issue where previously, if you replied to a note in the activity stream, you would see the note twice - once right at the top with the new reply and once further down without the reply. (it was only a temporary state, a UI refresh would make it go way). This change hides the note further down in the list, so that you only see the note once, first in the activity stream. 