### PR TITLE
#38383 SG menu now scrollable when size extends beyond height of display

### DIFF
--- a/python/shotgun_menus/entity_field_menu.py
+++ b/python/shotgun_menus/entity_field_menu.py
@@ -84,7 +84,7 @@ class EntityFieldMenu(ShotgunMenu):
                                cache location will be returned if the current
                                context does not have an associated project.
         """
-        QtGui.QMenu.__init__(self, parent=None)
+        super(EntityFieldMenu, self).__init__(parent)
 
         self._sg_entity_type = sg_entity_type
 

--- a/python/shotgun_menus/shotgun_menu.py
+++ b/python/shotgun_menus/shotgun_menu.py
@@ -35,6 +35,20 @@ class ShotgunMenu(QtGui.QMenu):
     Image shows the results of the ``ShotgunMenu`` created in the example.
     """
 
+    def __init__(self, parent=None):
+        """
+        Initialize the menu.
+
+        :param parent: The menu's parent.
+        :type parent: :class:`~PySide.QtGui.QWidget`
+        """
+
+        super(ShotgunMenu, self).__init__(parent)
+
+        # ensure the menu only takes up one column and scrolls rather than
+        # expanding horizontally (the default)
+        self.setStyleSheet("QMenu { menu-scrollable: 1; }")
+
     def add_group(self, items, title=None, separator=True):
         """
         Adds a group of items to the menu.


### PR DESCRIPTION
Very small change that adds `menu-scrollable` style to prevent the menu from ballooning horizontally when then size extends beyond the height of the display. Menus will now display scroll indicators at the top and bottom and will never be wider than a single column.

![image](https://cloud.githubusercontent.com/assets/2604646/18889985/6aa36606-84cd-11e6-9f19-8d27c7385eca.png)
