### PR TITLE
#38369: Hyperlink styling

### DIFF
--- a/framework.py
+++ b/framework.py
@@ -20,5 +20,33 @@ class QtWidgetFramework(sgtk.platform.Framework):
     
     def destroy_framework(self):
         self.log_debug("%s: Destroying..." % self)
+
+    ##########################################################################################
+    # public methods
+
+    def get_hyperlink_html(self, url, name):
+        """
+        Provides an html string for a hyperlink pointing to the given URL
+        and displaying the provided string name.
+
+        :param str url: The URL that the hyperlink navigates to.
+        :param str name: The string name to display.
+
+        :return: HTML string.
+        """
+        # Older versions of core don't have the SG_LINK_COLOR constant, so we'll
+        # just fall back on SG_FOREGROUND_COLOR in that case.
+        color = self.style_constants.get(
+            "SG_LINK_COLOR",
+            self.style_constants["SG_FOREGROUND_COLOR"]
+        )
+
+        html = "<a href='%s' style='text-decoration: none; color: %s'><b>%s</b></a>" % (
+            url,
+            color,
+            name,
+        )
+
+        return html
     
     

--- a/framework.py
+++ b/framework.py
@@ -20,33 +20,5 @@ class QtWidgetFramework(sgtk.platform.Framework):
     
     def destroy_framework(self):
         self.log_debug("%s: Destroying..." % self)
-
-    ##########################################################################################
-    # public methods
-
-    def get_hyperlink_html(self, url, name):
-        """
-        Provides an html string for a hyperlink pointing to the given URL
-        and displaying the provided string name.
-
-        :param str url: The URL that the hyperlink navigates to.
-        :param str name: The string name to display.
-
-        :return: HTML string.
-        """
-        # Older versions of core don't have the SG_LINK_COLOR constant, so we'll
-        # just fall back on SG_FOREGROUND_COLOR in that case.
-        color = self.style_constants.get(
-            "SG_LINK_COLOR",
-            self.style_constants["SG_FOREGROUND_COLOR"]
-        )
-
-        html = "<a href='%s' style='text-decoration: none; color: %s'><b>%s</b></a>" % (
-            url,
-            color,
-            name,
-        )
-
-        return html
     
     

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Shotgun Software Inc.
+# Copyright (c) 2016 Shotgun Software Inc.
 # 
 # CONFIDENTIAL AND PROPRIETARY
 # 
@@ -8,6 +8,7 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+from . import utils
 from . import playback_label
 from . import views
 from . import models

--- a/python/activity_stream/widget_activity_stream_base.py
+++ b/python/activity_stream/widget_activity_stream_base.py
@@ -9,7 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from sgtk.platform.qt import QtCore, QtGui
-from sgtk.platform import constants
+from sgtk.platform import get_hyperlink_html
 
 import sgtk
 import datetime
@@ -201,19 +201,11 @@ class ActivityStreamBaseWidget(QtGui.QWidget):
             return str(day_diff / 30) + " months ago"
         return str(day_diff / 365) + " years ago"
                      
-    # CBB? we are generating HTML links here and they were
-    # styled thusly. i could not style them via setStyleSheet either.
-    # anyway, i think this could be done another way later?
-    # - stewartb
     def __generate_url(self, entity_type, entity_id, name):
         """
         Generate a standard shotgun url
         """
-        str_val = constants.URL_TEMPLATE % (
-            "%s:%s" % (entity_type, entity_id),
-            name,
-        )
-        return str_val
+        return get_hyperlink_html("{0}:{1}".format(entity_type, entity_id), name)
     
     def _generate_entity_url(self, entity, this_syntax=True, display_type=True):
         """

--- a/python/activity_stream/widget_activity_stream_base.py
+++ b/python/activity_stream/widget_activity_stream_base.py
@@ -205,7 +205,7 @@ class ActivityStreamBaseWidget(QtGui.QWidget):
         Generate a standard shotgun url
         """
         return self._bundle.get_hyperlink_html(
-            url="{0}:{1}".format(entity_type, entity_id),
+            url="%s:%s" % (entity_type, entity_id),
             name=name,
         )
     

--- a/python/activity_stream/widget_activity_stream_base.py
+++ b/python/activity_stream/widget_activity_stream_base.py
@@ -13,6 +13,8 @@ from sgtk.platform.qt import QtCore, QtGui
 import sgtk
 import datetime
 
+from ..utils import get_hyperlink_html
+
 shotgun_globals = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_globals")
 
 class ActivityStreamBaseWidget(QtGui.QWidget):
@@ -204,7 +206,7 @@ class ActivityStreamBaseWidget(QtGui.QWidget):
         """
         Generate a standard shotgun url
         """
-        return self._bundle.get_hyperlink_html(
+        return get_hyperlink_html(
             url="%s:%s" % (entity_type, entity_id),
             name=name,
         )

--- a/python/activity_stream/widget_activity_stream_base.py
+++ b/python/activity_stream/widget_activity_stream_base.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from sgtk.platform.qt import QtCore, QtGui
+from sgtk.platform import constants
 
 import sgtk
 import datetime
@@ -208,14 +209,10 @@ class ActivityStreamBaseWidget(QtGui.QWidget):
         """
         Generate a standard shotgun url
         """
-        str_val = """<a href='%s:%s' 
-                        style='text-decoration: none;
-                        color: %s'>%s</a>
-                  """ % (entity_type, 
-                         entity_id,
-                         #self._bundle.style_constants["SG_HIGHLIGHT_COLOR"],
-                         'rgb(126,127,129);',
-                         name)
+        str_val = constants.URL_TEMPLATE % (
+            "%s:%s" % (entity_type, entity_id),
+            name,
+        )
         return str_val
     
     def _generate_entity_url(self, entity, this_syntax=True, display_type=True):

--- a/python/activity_stream/widget_activity_stream_base.py
+++ b/python/activity_stream/widget_activity_stream_base.py
@@ -9,7 +9,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from sgtk.platform.qt import QtCore, QtGui
-from sgtk.platform import get_hyperlink_html
 
 import sgtk
 import datetime
@@ -205,7 +204,10 @@ class ActivityStreamBaseWidget(QtGui.QWidget):
         """
         Generate a standard shotgun url
         """
-        return get_hyperlink_html("{0}:{1}".format(entity_type, entity_id), name)
+        return self._bundle.get_hyperlink_html(
+            url="{0}:{1}".format(entity_type, entity_id),
+            name=name,
+        )
     
     def _generate_entity_url(self, entity, this_syntax=True, display_type=True):
         """

--- a/python/shotgun_fields/entity_widget.py
+++ b/python/shotgun_fields/entity_widget.py
@@ -45,7 +45,7 @@ class EntityWidget(ElidedLabelBaseWidget):
         entity_url = "%sdetail/%s/%d" % (url_base, value["type"], value["id"])
         entity_icon_url = shotgun_globals.get_entity_type_icon_url(value["type"])
 
-        hyperlink = sgtk.platform.get_hyperlink_html(entity_url, str_val)
+        hyperlink = self._bundle.get_hyperlink_html(entity_url, str_val)
         return "<span><img src='{0}'>&nbsp;{1}".format(entity_icon_url, hyperlink)
 
     def _string_value(self, value):

--- a/python/shotgun_fields/entity_widget.py
+++ b/python/shotgun_fields/entity_widget.py
@@ -42,23 +42,11 @@ class EntityWidget(ElidedLabelBaseWidget):
         else:
             url_base = "%s/" % self._bundle.sgtk.shotgun_url
 
-        # SG_LINK_COLOR is newer to core than the highlight color, so we'll
-        # fall back on highlight if the explicit link color isn't available.
-        style_constants = sgtk.platform.current_bundle().style_constants
-        link_color = style_constants.get(
-            "SG_LINK_COLOR",
-            style_constants["SG_HIGHLIGHT_COLOR"],
-        )
-
         entity_url = "%sdetail/%s/%d" % (url_base, value["type"], value["id"])
         entity_icon_url = shotgun_globals.get_entity_type_icon_url(value["type"])
-        str_val = (
-            "<span><img src='%s'>&nbsp;"
-            "<a href='%s'><font color='%s'>%s</font></a></span>"
-             % (entity_icon_url, entity_url, link_color, str_val)
-        )
 
-        return str_val
+        hyperlink = sgtk.platform.get_hyperlink_html(entity_url, str_val)
+        return "<span><img src='{0}'>&nbsp;{1}".format(entity_icon_url, hyperlink)
 
     def _string_value(self, value):
         """

--- a/python/shotgun_fields/entity_widget.py
+++ b/python/shotgun_fields/entity_widget.py
@@ -46,7 +46,7 @@ class EntityWidget(ElidedLabelBaseWidget):
         entity_icon_url = shotgun_globals.get_entity_type_icon_url(value["type"])
 
         hyperlink = self._bundle.get_hyperlink_html(entity_url, str_val)
-        return "<span><img src='{0}'>&nbsp;{1}".format(entity_icon_url, hyperlink)
+        return "<span><img src='%s'>&nbsp;%s</span>" % (entity_icon_url, hyperlink)
 
     def _string_value(self, value):
         """

--- a/python/shotgun_fields/entity_widget.py
+++ b/python/shotgun_fields/entity_widget.py
@@ -14,6 +14,7 @@ from sgtk.platform.qt import QtCore, QtGui
 from .label_base_widget import ElidedLabelBaseWidget
 from .shotgun_field_meta import ShotgunFieldMeta
 from .util import check_project_search_supported
+from ..utils import get_hyperlink_html
 
 shotgun_globals = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_globals")
 global_search_widget = sgtk.platform.current_bundle().import_module("global_search_widget")
@@ -45,7 +46,7 @@ class EntityWidget(ElidedLabelBaseWidget):
         entity_url = "%sdetail/%s/%d" % (url_base, value["type"], value["id"])
         entity_icon_url = shotgun_globals.get_entity_type_icon_url(value["type"])
 
-        hyperlink = self._bundle.get_hyperlink_html(entity_url, str_val)
+        hyperlink = get_hyperlink_html(entity_url, str_val)
         return "<span><img src='%s'>&nbsp;%s</span>" % (entity_icon_url, hyperlink)
 
     def _string_value(self, value):

--- a/python/shotgun_fields/file_link_widget.py
+++ b/python/shotgun_fields/file_link_widget.py
@@ -15,9 +15,11 @@ from sgtk.platform.qt import QtCore, QtGui
 
 from .label_base_widget import ElidedLabelBaseWidget
 from .shotgun_field_meta import ShotgunFieldMeta
+from ..utils import get_hyperlink_html
 
 # ensures access to `link_menu.png`
 from .ui import resources_rc
+
 
 
 class FileLinkWidget(ElidedLabelBaseWidget):
@@ -308,7 +310,7 @@ class FileLinkWidget(ElidedLabelBaseWidget):
         if value["link_type"] in ["web", "upload"]:
             url = value["url"]
             img_src = ":/qtwidgets-shotgun-fields/link_%s.png" % (value["link_type"],)
-            hyperlink = self._bundle.get_hyperlink_html(url, value.get("name", url))
+            hyperlink = get_hyperlink_html(url, value.get("name", url))
             str_val = "<span><img src='%s'>&nbsp;%s</span>" % (img_src, hyperlink)
         elif value["link_type"] == "local":
             local_path = value["local_path"]
@@ -317,7 +319,7 @@ class FileLinkWidget(ElidedLabelBaseWidget):
             # file basename.ext (the SG behavior).
             file_name = os.path.split(local_path)[-1]
             img_src = ":/qtwidgets-shotgun-fields/link_%s.png" % (value["link_type"],)
-            hyperlink = self._bundle.get_hyperlink_html(local_path, file_name)
+            hyperlink = get_hyperlink_html(local_path, file_name)
             str_val = "<span><img src='%s'>&nbsp;%s</span>" % (img_src, hyperlink)
         else:
             str_val = ""

--- a/python/shotgun_fields/file_link_widget.py
+++ b/python/shotgun_fields/file_link_widget.py
@@ -308,7 +308,7 @@ class FileLinkWidget(ElidedLabelBaseWidget):
         if value["link_type"] in ["web", "upload"]:
             url = value["url"]
             img_src = ":/qtwidgets-shotgun-fields/link_%s.png" % (value["link_type"],)
-            hyperlink = sgtk.platform.get_hyperlink_html(url, value.get("name", url))
+            hyperlink = self._bundle.get_hyperlink_html(url, value.get("name", url))
             str_val = "<span><img src='{0}'>&nbsp;{1}".format(img_src, hyperlink)
         elif value["link_type"] == "local":
             local_path = value["local_path"]
@@ -317,7 +317,7 @@ class FileLinkWidget(ElidedLabelBaseWidget):
             # file basename.ext (the SG behavior).
             file_name = os.path.split(local_path)[-1]
             img_src = ":/qtwidgets-shotgun-fields/link_%s.png" % (value["link_type"],)
-            hyperlink = sgtk.platform.get_hyperlink_html(local_path, file_name)
+            hyperlink = self._bundle.get_hyperlink_html(local_path, file_name)
             str_val = "<span><img src='{0}'>&nbsp;{1}".format(img_src, hyperlink)
         else:
             str_val = ""

--- a/python/shotgun_fields/file_link_widget.py
+++ b/python/shotgun_fields/file_link_widget.py
@@ -309,7 +309,7 @@ class FileLinkWidget(ElidedLabelBaseWidget):
             url = value["url"]
             img_src = ":/qtwidgets-shotgun-fields/link_%s.png" % (value["link_type"],)
             hyperlink = self._bundle.get_hyperlink_html(url, value.get("name", url))
-            str_val = "<span><img src='{0}'>&nbsp;{1}".format(img_src, hyperlink)
+            str_val = "<span><img src='%s'>&nbsp;%s</span>" % (img_src, hyperlink)
         elif value["link_type"] == "local":
             local_path = value["local_path"]
             # for file on OS that differs from the current OS, this will
@@ -318,7 +318,7 @@ class FileLinkWidget(ElidedLabelBaseWidget):
             file_name = os.path.split(local_path)[-1]
             img_src = ":/qtwidgets-shotgun-fields/link_%s.png" % (value["link_type"],)
             hyperlink = self._bundle.get_hyperlink_html(local_path, file_name)
-            str_val = "<span><img src='{0}'>&nbsp;{1}".format(img_src, hyperlink)
+            str_val = "<span><img src='%s'>&nbsp;%s</span>" % (img_src, hyperlink)
         else:
             str_val = ""
 

--- a/python/shotgun_fields/file_link_widget.py
+++ b/python/shotgun_fields/file_link_widget.py
@@ -305,24 +305,11 @@ class FileLinkWidget(ElidedLabelBaseWidget):
         :param value: The value to convert into a string
         :type value: A dictionary as returned by the Shotgun API for a url field
         """
-
-        # SG_LINK_COLOR is newer to core than the highlight color, so we'll
-        # fall back on highlight if the explicit link color isn't available.
-        style_constants = sgtk.platform.current_bundle().style_constants
-        link_color = style_constants.get(
-            "SG_LINK_COLOR",
-            style_constants["SG_HIGHLIGHT_COLOR"],
-        )
-
         if value["link_type"] in ["web", "upload"]:
             url = value["url"]
             img_src = ":/qtwidgets-shotgun-fields/link_%s.png" % (value["link_type"],)
-            str_val = value.get("name", url)
-            str_val = (
-                "<span><img src='%s'>&nbsp;"
-                "<a href='%s'><font color='%s'>%s</font></a></span>"
-                % (img_src, url, link_color, str_val)
-            )
+            hyperlink = sgtk.platform.get_hyperlink_html(url, value.get("name", url))
+            str_val = "<span><img src='{0}'>&nbsp;{1}".format(img_src, hyperlink)
         elif value["link_type"] == "local":
             local_path = value["local_path"]
             # for file on OS that differs from the current OS, this will
@@ -330,11 +317,8 @@ class FileLinkWidget(ElidedLabelBaseWidget):
             # file basename.ext (the SG behavior).
             file_name = os.path.split(local_path)[-1]
             img_src = ":/qtwidgets-shotgun-fields/link_%s.png" % (value["link_type"],)
-            str_val = (
-                "<span><img src='%s'>&nbsp;"
-                "<a href='file:///%s'><font color='%s'>%s</font></a></span>"
-                % (img_src, local_path, link_color, file_name)
-            )
+            hyperlink = sgtk.platform.get_hyperlink_html(local_path, file_name)
+            str_val = "<span><img src='{0}'>&nbsp;{1}".format(img_src, hyperlink)
         else:
             str_val = ""
 

--- a/python/shotgun_fields/url_template_widget.py
+++ b/python/shotgun_fields/url_template_widget.py
@@ -11,6 +11,7 @@
 import sgtk
 from .label_base_widget import ElidedLabelBaseWidget
 from .shotgun_field_meta import ShotgunFieldMeta
+from ..utils import get_hyperlink_html
 
 
 class UrlTemplateWidget(ElidedLabelBaseWidget):
@@ -26,7 +27,4 @@ class UrlTemplateWidget(ElidedLabelBaseWidget):
 
         :param str value: The url value to convert into a string
         """
-        return self._bundle.get_hyperlink_html(
-            url=value,
-            name=value,
-        )
+        return get_hyperlink_html(url=value, name=value)

--- a/python/shotgun_fields/url_template_widget.py
+++ b/python/shotgun_fields/url_template_widget.py
@@ -26,7 +26,7 @@ class UrlTemplateWidget(ElidedLabelBaseWidget):
 
         :param str value: The url value to convert into a string
         """
-        return sgtk.platform.get_hyperlink_html(
+        return self._bundle.get_hyperlink_html(
             url=value,
             name=value,
         )

--- a/python/shotgun_fields/url_template_widget.py
+++ b/python/shotgun_fields/url_template_widget.py
@@ -26,12 +26,7 @@ class UrlTemplateWidget(ElidedLabelBaseWidget):
 
         :param str value: The url value to convert into a string
         """
-        # SG_LINK_COLOR is newer to core than the highlight color, so we'll
-        # fall back on highlight if the explicit link color isn't available.
-        style_constants = sgtk.platform.current_bundle().style_constants
-        link_color = style_constants.get(
-            "SG_LINK_COLOR",
-            style_constants["SG_HIGHLIGHT_COLOR"],
+        return sgtk.platform.get_hyperlink_html(
+            url=value,
+            name=value,
         )
-        return "<a href='%s'><font color='%s'>%s</font></a>" % (
-            value, link_color, value)

--- a/python/utils.py
+++ b/python/utils.py
@@ -1,0 +1,36 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import sgtk
+
+def get_hyperlink_html(url, name):
+    """
+    Provides an html string for a hyperlink pointing to the given URL
+    and displaying the provided string name.
+
+    :param str url: The URL that the hyperlink navigates to.
+    :param str name: The string name to display.
+
+    :return: HTML string.
+    """
+    # Older versions of core don't have the SG_LINK_COLOR constant, so we'll
+    # just fall back on SG_FOREGROUND_COLOR in that case.
+    color = sgtk.platform.constants.SG_STYLESHEET_CONSTANTS.get(
+        "SG_LINK_COLOR",
+        sgtk.platform.constants.SG_STYLESHEET_CONSTANTS["SG_FOREGROUND_COLOR"]
+    )
+
+    html = "<a href='%s' style='text-decoration: none; color: %s'><b>%s</b></a>" % (
+        url,
+        color,
+        name,
+    )
+
+    return html


### PR DESCRIPTION
Makes use of sgtk.platform.get_hyperlink_html() when building url labels. The activity stream and shotgun_fields now use foreground colored, bold text for url labels.

**_NOTE:_** Pages other than the Activity Stream in the Shotgun Panel app remain unchanged. They make use of get_hyperlink_html, but they do so in a way that maintains their current styling.

![panel](https://cloud.githubusercontent.com/assets/4913787/19098350/5b62f05a-8a61-11e6-9084-565a513f1397.png)

![version_details](https://cloud.githubusercontent.com/assets/4913787/19098352/5dea74f6-8a61-11e6-857a-95c3f59ce5dc.png)
