### PR TITLE
Make the border of the note match the border of the note input box.

### DIFF
--- a/python/activity_stream/widget_note.py
+++ b/python/activity_stream/widget_note.py
@@ -304,7 +304,7 @@ class NoteWidget(ActivityStreamBaseWidget):
                 )
             )
         else:
-            self.setStyleSheet("#frame { border: 1px solid transparent }")
+            self.setStyleSheet("#frame { border: 1px solid rgba(255,255,255, 20%) }")
 
         self.selection_changed.emit(self.selected, self._note_id)
         

--- a/python/activity_stream/widget_note.py
+++ b/python/activity_stream/widget_note.py
@@ -66,7 +66,7 @@ class NoteWidget(ActivityStreamBaseWidget):
         # We set a transparent border initially, because we don't want to
         # see the widget "jump" in its size/placement when it is selected
         # and the colored border appears.
-        self.setStyleSheet("#frame { border: 1px solid transparent }")
+        self.setStyleSheet("#frame { border: 1px solid rgba(255,255,255, 20%) }")
         self.set_selected(False)
 
         # make sure clicks propagate upwards in the hierarchy


### PR DESCRIPTION
This was a design change request made by Bill Bulman, in line with the future direction of the Shotgun website.

It adds a grey highlight border around the note:
![image](https://cloud.githubusercontent.com/assets/1420734/19524177/2683e598-961d-11e6-895f-866cc3cdf273.png)
