### PR TITLE
Use underMouse instead of rect contains to detect note selection.

### DIFF
--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -1069,8 +1069,7 @@ class ActivityStreamWidget(QtGui.QWidget):
 
         for widget in self._activity_stream_data_widgets.values():
             if isinstance(widget, NoteWidget):
-                selected = widget.rect().contains(widget.mapFromGlobal(position))
-
+                selected = widget.underMouse()
                 if selected != widget.selected:
                     widget.set_selected(selected)
                     self._note_selected_changed(selected, widget.note_id)


### PR DESCRIPTION
The following reproduction steps revealed a strange bug with note selection in Dynamite:
1. Create two notes
2. Select the bottom note and add a reply
3. Select the other note (now at the bottom) and add a reply
Click back and forth in the notes and multiple times in the following areas:
![image](https://cloud.githubusercontent.com/assets/1420734/19522215/a0aba7cc-9616-11e6-8d98-1a6ccb2f6ac7.png)

Note that the notes will be improperly deselected or selected.

This problem was fixed by using the `underMouse` property instead of checking the rect.
