### PR TITLE
#39094 Fixes default key navigation in SG menu

### DIFF
--- a/python/shotgun_menus/shotgun_menu.py
+++ b/python/shotgun_menus/shotgun_menu.py
@@ -191,6 +191,13 @@ class ShotgunMenu(QtGui.QMenu):
             # add it to the typed text
             self._typed_text += event_text
 
+        # not a key we want to process. call the base class implementation.
+        else:
+            # didn't find a match, call the base class
+            super(ShotgunMenu, self).keyReleaseEvent(event)
+            self._type_timer.start()
+            return
+
         # now search the actions to see if one matches the typed text
         for action in self.actions():
             # use a try to ignore any possible errors
@@ -206,9 +213,6 @@ class ShotgunMenu(QtGui.QMenu):
             except Exception, e:
                 # assume no match
                 pass
-
-        # didn't find a match, call the base class
-        super(ShotgunMenu, self).keyReleaseEvent(event)
 
         # ensure the timer is started
         self._type_timer.start()

--- a/python/shotgun_menus/shotgun_menu.py
+++ b/python/shotgun_menus/shotgun_menu.py
@@ -192,7 +192,8 @@ class ShotgunMenu(QtGui.QMenu):
             self._typed_text += event_text
 
         else:
-            # didn't find a match, call the base class
+            # the typed key isn't one we recognize for matching. call the
+            # default implementation
             super(ShotgunMenu, self).keyReleaseEvent(event)
             self._type_timer.start()
             return
@@ -212,6 +213,9 @@ class ShotgunMenu(QtGui.QMenu):
             except Exception, e:
                 # assume no match
                 pass
+
+        # didn't find a match, call the base class
+        super(ShotgunMenu, self).keyReleaseEvent(event)
 
         # ensure the timer is started
         self._type_timer.start()

--- a/python/shotgun_menus/shotgun_menu.py
+++ b/python/shotgun_menus/shotgun_menu.py
@@ -191,7 +191,6 @@ class ShotgunMenu(QtGui.QMenu):
             # add it to the typed text
             self._typed_text += event_text
 
-        # not a key we want to process. call the base class implementation.
         else:
             # didn't find a match, call the base class
             super(ShotgunMenu, self).keyReleaseEvent(event)


### PR DESCRIPTION
When the ability to type to highlight a menu item was added, it broke the default up/down arrow navigation. This PR allows the default behavior to work again.