### PR TITLE
Remove extra underscores in data_manager destroy()

### DIFF
--- a/python/activity_stream/data_manager.py
+++ b/python/activity_stream/data_manager.py
@@ -200,11 +200,11 @@ class ActivityStreamDataHandler(QtCore.QObject):
         """
         Should be called before the widget is closed
         """
-        if self.__sg_data_retriever:
-            self.__sg_data_retriever.stop()
-            self.__sg_data_retriever.work_completed.disconnect(self.__on_worker_signal)
-            self.__sg_data_retriever.work_failure.disconnect(self.__on_worker_failure)
-            self.__sg_data_retriever = None
+        if self._sg_data_retriever:
+            self._sg_data_retriever.stop()
+            self._sg_data_retriever.work_completed.disconnect(self.__on_worker_signal)
+            self._sg_data_retriever.work_failure.disconnect(self.__on_worker_failure)
+            self._sg_data_retriever = None
 
     def __reset(self):
         """


### PR DESCRIPTION
The activity stream's `data_manager.destroy()` method was expecting a double underscore data retriever instead of single underscore. Guessing this was changed at some point and this was just missed. This was causing an exception on close when destroy was called on the activity stream. This change simply removes the extra underscore which fixes the problem.