### PR TITLE
 #38573 Second pass to create a field delegate for use with non-SG model

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,6 @@ Contents:
    shotgun_fields
    shotgun_menus
    spinner_widget
-   playback_label
    views
 
 Importing widgets into your app

--- a/docs/note_input_widget.rst
+++ b/docs/note_input_widget.rst
@@ -1,4 +1,4 @@
-Shotgun Note editor widget
+Shotgun Note Input Widget
 #############################################
 
 The note editor widget makes it easy to add notes in Toolkit.

--- a/docs/overlay_widget.rst
+++ b/docs/overlay_widget.rst
@@ -1,4 +1,4 @@
-Spinner and text overlay widget
+Text Overlay Widget
 ######################################
 
 

--- a/docs/playback_label.rst
+++ b/docs/playback_label.rst
@@ -41,4 +41,4 @@ Use the label like this::
 
 .. autoclass:: ShotgunPlaybackLabel
     :show-inheritance:
-    :members: set_shotgun_data, playbable
+    :members: set_shotgun_data, playable

--- a/docs/shotgun_fields.rst
+++ b/docs/shotgun_fields.rst
@@ -472,8 +472,6 @@ in the layout.
 Field Widget Delegates
 ======================
 
-.. TODO
-
 .. currentmodule:: shotgun_fields.shotgun_field_delegate
 
 .. autoclass:: ShotgunFieldDelegate

--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -421,7 +421,9 @@ class ActivityStreamWidget(QtGui.QWidget):
                   "re" module documentation for Python 2.x for more information and
                   examples.
 
-        .. example:: To match only ".gif" extensions: re.compile(r"\w+[.]gif$")
+        Example to match only ".gif" extensions::
+
+            re.compile(r"\w+[.]gif$")
         """
         return self._attachments_filter
 

--- a/python/activity_stream/widget_activity_stream_base.py
+++ b/python/activity_stream/widget_activity_stream_base.py
@@ -13,9 +13,9 @@ from sgtk.platform.qt import QtCore, QtGui
 import sgtk
 import datetime
 
-from ..utils import get_hyperlink_html
-
 shotgun_globals = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_globals")
+
+utils = sgtk.platform.import_framework("tk-framework-shotgunutils", "utils")
 
 class ActivityStreamBaseWidget(QtGui.QWidget):
     """
@@ -207,7 +207,7 @@ class ActivityStreamBaseWidget(QtGui.QWidget):
         """
         Generate a standard shotgun url
         """
-        return get_hyperlink_html(
+        return utils.get_hyperlink_html(
             url="%s:%s" % (entity_type, entity_id),
             name=name,
         )

--- a/python/shotgun_fields/entity_widget.py
+++ b/python/shotgun_fields/entity_widget.py
@@ -14,10 +14,10 @@ from sgtk.platform.qt import QtCore, QtGui
 from .label_base_widget import ElidedLabelBaseWidget
 from .shotgun_field_meta import ShotgunFieldMeta
 from .util import check_project_search_supported
-from ..utils import get_hyperlink_html
 
 shotgun_globals = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_globals")
 global_search_widget = sgtk.platform.current_bundle().import_module("global_search_widget")
+utils = sgtk.platform.import_framework("tk-framework-shotgunutils", "utils")
 
 
 class EntityWidget(ElidedLabelBaseWidget):
@@ -46,7 +46,7 @@ class EntityWidget(ElidedLabelBaseWidget):
         entity_url = "%sdetail/%s/%d" % (url_base, value["type"], value["id"])
         entity_icon_url = shotgun_globals.get_entity_type_icon_url(value["type"])
 
-        hyperlink = get_hyperlink_html(entity_url, str_val)
+        hyperlink = utils.get_hyperlink_html(entity_url, str_val)
         return "<span><img src='%s'>&nbsp;%s</span>" % (entity_icon_url, hyperlink)
 
     def _string_value(self, value):

--- a/python/shotgun_fields/file_link_widget.py
+++ b/python/shotgun_fields/file_link_widget.py
@@ -15,7 +15,8 @@ from sgtk.platform.qt import QtCore, QtGui
 
 from .label_base_widget import ElidedLabelBaseWidget
 from .shotgun_field_meta import ShotgunFieldMeta
-from ..utils import get_hyperlink_html
+
+utils = sgtk.platform.import_framework("tk-framework-shotgunutils", "utils")
 
 # ensures access to `link_menu.png`
 from .ui import resources_rc
@@ -310,7 +311,7 @@ class FileLinkWidget(ElidedLabelBaseWidget):
         if value["link_type"] in ["web", "upload"]:
             url = value["url"]
             img_src = ":/qtwidgets-shotgun-fields/link_%s.png" % (value["link_type"],)
-            hyperlink = get_hyperlink_html(url, value.get("name", url))
+            hyperlink = utils.get_hyperlink_html(url, value.get("name", url))
             str_val = "<span><img src='%s'>&nbsp;%s</span>" % (img_src, hyperlink)
         elif value["link_type"] == "local":
             local_path = value["local_path"]
@@ -319,7 +320,7 @@ class FileLinkWidget(ElidedLabelBaseWidget):
             # file basename.ext (the SG behavior).
             file_name = os.path.split(local_path)[-1]
             img_src = ":/qtwidgets-shotgun-fields/link_%s.png" % (value["link_type"],)
-            hyperlink = get_hyperlink_html(local_path, file_name)
+            hyperlink = utils.get_hyperlink_html(local_path, file_name)
             str_val = "<span><img src='%s'>&nbsp;%s</span>" % (img_src, hyperlink)
         else:
             str_val = ""

--- a/python/shotgun_fields/image_widget.py
+++ b/python/shotgun_fields/image_widget.py
@@ -173,8 +173,9 @@ class ImageWidget(QtGui.QLabel):
             if (not self._delegate and
                 not isinstance(value, QtGui.QPixmap) and
                 not os.path.exists(value)):
-                # this is not a local file or a pre-created pixmap. we need to
-                # download it
+                # the widget isn't being used as a delegate (which never
+                # requires downloads) and the value is not a local file or a
+                # pre-created pixmap. so we need to download it.
                 self._needs_download = True
             self._display_value(value)
         self.value_changed.emit()

--- a/python/shotgun_fields/image_widget.py
+++ b/python/shotgun_fields/image_widget.py
@@ -170,7 +170,9 @@ class ImageWidget(QtGui.QLabel):
         if value is None:
             self._display_default()
         else:
-            if not isinstance(value, QtGui.QPixmap) and not os.path.exists(value):
+            if (not self._delegate and
+                not isinstance(value, QtGui.QPixmap) and
+                not os.path.exists(value)):
                 # this is not a local file or a pre-created pixmap. we need to
                 # download it
                 self._needs_download = True

--- a/python/shotgun_fields/shotgun_field_delegate.py
+++ b/python/shotgun_fields/shotgun_field_delegate.py
@@ -14,10 +14,12 @@ from sgtk.platform.qt import QtCore, QtGui
 views = sgtk.platform.current_bundle().import_module("views")
 
 shotgun_globals = sgtk.platform.import_framework(
-    "tk-framework-shotgunutils", "shotgun_globals")
+    "tk-framework-shotgunutils", "shotgun_globals"
+)
 
 shotgun_model = sgtk.platform.import_framework(
-    "tk-framework-shotgunutils", "shotgun_model")
+    "tk-framework-shotgunutils", "shotgun_model"
+)
 
 
 class ShotgunFieldDelegateGeneric(views.WidgetDelegate):
@@ -27,10 +29,10 @@ class ShotgunFieldDelegateGeneric(views.WidgetDelegate):
     This class is designed to be used with any model that represents data that
     can be stored in Shotgun fields.
 
-    The included ``ShotgunFieldDelegate`` class is designed to work specifically
-    with ``ShotgunModel`` instances. For other model types use this class and
-    supply a ``field_data_role`` to this class constructor. The default is
-    ``QtCore.Qt.EditRole``.
+    The included subclass, ``ShotgunFieldDelegate``, is designed to work
+    specifically with ``ShotgunModel`` instances. For other model types use this
+    class and supply a ``field_data_role`` to this class constructor. The
+    default is ``QtCore.Qt.EditRole``.
     """
 
     def __init__(self, sg_entity_type, field_name, display_class, editor_class,

--- a/python/shotgun_fields/shotgun_field_delegate.py
+++ b/python/shotgun_fields/shotgun_field_delegate.py
@@ -12,16 +12,30 @@ import sgtk
 from sgtk.platform.qt import QtCore, QtGui
 
 views = sgtk.platform.current_bundle().import_module("views")
-shotgun_globals = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_globals")
-shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
 
-class ShotgunFieldDelegate(views.WidgetDelegate):
+shotgun_globals = sgtk.platform.import_framework(
+    "tk-framework-shotgunutils", "shotgun_globals")
+
+shotgun_model = sgtk.platform.import_framework(
+    "tk-framework-shotgunutils", "shotgun_model")
+
+
+class ShotgunFieldDelegateGeneric(views.WidgetDelegate):
     """
-    A delegate for a given type of Shotgun field.  This delegate is designed to work
-    with indexes from a ShotgunModel where the value of the field is stored in the
-    SG_ASSOCIATED_FIELD_ROLE role.
+    A generic, model-agnostic, shotgun field widget delegate.
+
+    This class is designed to be used with any model that represents data that
+    can be stored in Shotgun fields.
+
+    The included ``ShotgunFieldDelegate`` class is designed to work specifically
+    with ``ShotgunModel`` instances. For other model types use this class and
+    supply a ``field_data_role`` to this class constructor. The default is
+    ``QtCore.Qt.EditRole``.
     """
-    def __init__(self, sg_entity_type, field_name, display_class, editor_class, view, bg_task_manager=None):
+
+    def __init__(self, sg_entity_type, field_name, display_class, editor_class,
+                 view, bg_task_manager=None,
+                 field_data_role=QtCore.Qt.EditRole):
         """
         Constructor
 
@@ -31,14 +45,26 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
         :param field_name: Shotgun field name
         :type field_name: String
 
-        :param display_class: A shotgun field :class:`~PySide.QtGui.QWidget` to display the field info
+        :param display_class: A shotgun field :class:`~PySide.QtGui.QWidget` to
+            display the field info
 
-        :param editor_class: A shotgun field :class:`~PySide.QtGui.QWidget` to edit the field info
+        :param editor_class: A shotgun field :class:`~PySide.QtGui.QWidget` to
+            edit the field info
 
         :param view: The parent view for this delegate
         :type view:  :class:`~PySide.QtGui.QWidget`
+
+        :param bg_task_manager: Optional Task manager.  If this is not passed in
+            one will be created when the delegate widget is created.
+        :type bg_task_manager: :class:`~task_manager.BackgroundTaskManager`
+
+        :param int field_data_role: The data role that stores SG field data in
+            the model where this delegate is to be used.
         """
         views.WidgetDelegate.__init__(self, view)
+
+        # The model role used to get/set values for editing the field widget
+        self._field_data_role = field_data_role
 
         self._entity_type = sg_entity_type
         self._field_name = field_name
@@ -46,17 +72,29 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
         self._editor_class = editor_class
         self._bg_task_manager = bg_task_manager
 
+    @property
+    def field_data_role(self):
+        """
+        The item role used to get and set data associated with the fields being
+        represented by this delegate.
+        """
+        return self._field_data_role
+
     def paint(self, painter, style_options, model_index):
         """
         Paint method to handle all cells that are not being currently edited.
 
-        :param painter:         The painter instance to use when painting
-        :param style_options:   The style options to use when painting
-        :param model_index:     The index in the data model that needs to be painted
+        :param painter: The painter instance to use when painting
+        :param style_options: The style options to use when painting
+        :param model_index: The index in the data model that needs to be painted
         """
 
         # let the base class do all the heavy lifting
-        super(ShotgunFieldDelegate, self).paint(painter, style_options, model_index)
+        super(ShotgunFieldDelegateGeneric, self).paint(
+            painter,
+            style_options,
+            model_index
+        )
 
         # clear out the paint widget's contents to prevent it from showing in
         # other places in the view (since the widget is shared)
@@ -65,6 +103,8 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
 
     def _create_widget(self, parent):
         """
+        Creates a widget to use for the delegate.
+
         :param parent: QWidget to parent the widget to
         :type parent: :class:`~PySide.QtGui.QWidget`
 
@@ -118,10 +158,12 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
         """
         Create an editor widget for the supplied model index.
 
-        :param model_index: The index of the item in the model to return a widget for
+        :param model_index: The index of the item in the model to return a
+            widget for
         :type model_index: :class:`~PySide.QtCore.QModelIndex`
 
-        :param style_options: Specifies the current Qt style options for this index
+        :param style_options: Specifies the current Qt style options for this
+            index
         :type style_options: :class:`~PySide.QtGui.QStyleOptionViewItem`
 
         :param parent: The parent view that the widget should be parented to
@@ -131,7 +173,8 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
         :rtype: :class:`~PySide.QtGui.QWidget`
         """
         # ensure the field is editable
-        if not shotgun_globals.field_is_editable(self._entity_type, self._field_name):
+        if not shotgun_globals.field_is_editable(self._entity_type,
+                                                 self._field_name):
             return None
 
         if not model_index.isValid():
@@ -161,12 +204,12 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
 
     def _on_before_paint(self, widget, model_index, style_options):
         """
-        Update the display widget with the value stored in the index's
-        SG_ASSOCIATED_FIELD_ROLE role.
+        Update the display widget with the value stored in the supplied model
+        index. The value is retrieved for the role supplied to the
+        ``field_data_role`` argument supplied to the constructor.
 
         :param widget: The QWidget (constructed in _create_widget()) which will
             be used to paint the cell.
-        :type parent: :class:`~PySide.QtGui.QWidget`
 
         :param model_index: object representing the data of the object that is
             about to be drawn.
@@ -178,7 +221,7 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
         """
 
         # make sure the display widget is populated with the correct data
-        _set_widget_value(widget, model_index)
+        self._set_widget_value(widget, model_index)
 
     def setEditorData(self, editor, model_index):
         """
@@ -192,54 +235,38 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
         """
 
         # make sure the editor widget is populated with the correct data
-        _set_widget_value(editor, model_index)
+        self._set_widget_value(editor, model_index)
 
     def setModelData(self, editor, model, index):
         """
-        Gets data from the editor widget and stores it in the specified model at the item index.
+        Gets data from the editor widget and stores it in the specified model at
+        the item index.
 
         :param editor: The editor widget.
         :type editor: :class:`~PySide.QtGui.QWidget`
         :param model: The SG model where the data lives.
-        :type model: :class:`~shotgun_utils.shotgun_model.ShotgunModel`
+        :type model: :class:`~PySide.QtCore.QAbstractItemModel`
         :param index: The index of the model to be edited.
         :type index: :class:`~PySide.QtCore.QModelIndex`
         """
         src_index = _map_to_source(index)
         if not src_index or not src_index.isValid():
-            # invalide index, do nothing
+            # invalid index, do nothing
             return
 
+        # compare the new/old values to see if there is a change
         new_value = editor.get_value()
-
-        cur_value = src_index.data(shotgun_model.ShotgunModel.SG_ASSOCIATED_FIELD_ROLE)
+        cur_value = src_index.data(self.field_data_role)
         if cur_value == new_value:
             # value didn't change. nothing to do here.
             return
 
-        bundle = sgtk.platform.current_bundle()
-
-        # special case for image fields
-        if editor._field_name == "image":
-            primary_item = src_index.model().item(src_index.row(), 0)
-            try:
-                if new_value:
-                    # update the value locally in the model
-                    primary_item.setIcon(QtGui.QIcon(new_value))
-                else:
-                    primary_item.setIcon(QtGui.QIcon())
-            except Exception, e:
-                bundle.log_error("Unable to set icon for widget delegate: %s" % (e,))
-
-            return
-
+        # attempt to set the new value in the model
         successful = src_index.model().setData(
-            src_index,
-            new_value,
-            shotgun_model.ShotgunModel.SG_ASSOCIATED_FIELD_ROLE,
-        )
+            src_index, new_value, self.field_data_role)
 
         if not successful:
+            bundle = sgtk.platform.current_bundle()
             bundle.log_error(
                 "Unable to set model data for widget delegate: %s, %s" %
                 (self._entity_type, self._field_name)
@@ -251,10 +278,13 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
 
         :param event: The event that occurred.
         :type event: :class:`~PySide.QtCore.QEvent`
+
         :param model: The SG model where the data lives.
-        :type model: :class:`~shotgun_utils.shotgun_model.ShotgunModel`
+        :type model: :class:`~PySide.QtCore.QAbstractItemModel`
+
         :param option: Options for rendering the item.
         :type option: :class:`~PySide.QtQui.QStyleOptionViewItem`
+
         :param index: The index of the model to be edited.
         :type index: :class:`~PySide.QtCore.QModelIndex`
 
@@ -289,7 +319,6 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
         interacting with the widget. This is necessary since the delegate only
         paints the widget in the view rather than being an actual widget
         instance.
-
         :param mouse_event: The event that occured on the delegate.
         :type mouse_event: :class:`~PySide.QtCore.QEvent`
         :param index: The model index that was acted on.
@@ -299,7 +328,7 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
         # get the widget used to paint this index, populate it with the
         # value for this index
         widget = self._get_painter_widget(index, self.view)
-        _set_widget_value(widget, index)
+        self._set_widget_value(widget, index)
 
         item_rect = self.view.visualRect(index)
 
@@ -326,50 +355,166 @@ class ShotgunFieldDelegate(views.WidgetDelegate):
         )
         QtGui.QApplication.sendEvent(widget, forward_event)
 
+    def _set_widget_value(self, widget, model_index):
+        """
+        Updates the supplied widget with data from the supplied model index.
 
-def _set_widget_value(widget, model_index):
+        :param widget: The widget to set the value for
+        :param model_index: The index of the model where the data comes from
+        :type model_index: :class:`~PySide.QtCore.QModelIndex`
+        """
+
+        src_index = _map_to_source(model_index)
+        if not src_index or not src_index.isValid():
+            # invalid index, do nothing
+            return
+
+        value = src_index.data(self.field_data_role)
+        widget.set_value(shotgun_model.sanitize_qt(value))
+
+
+class ShotgunFieldDelegate(ShotgunFieldDelegateGeneric):
     """
-    Updates the supplied widget with data from the supplied model index.
-
-    :param widget: The widget to set the value for
-    :type parent: :class:`~PySide.QtGui.QWidget`
-    :param model_index: The index of the model where the data comes from
-    :type model_index: :class:`~PySide.QtCore.QModelIndex`
+    A delegate for a given type of Shotgun field. This delegate is designed to
+    work with indexes from a ``ShotgunModel`` where the value of the field is
+    stored in the ``SG_ASSOCIATED_FIELD_ROLE`` role.
     """
 
-    src_index = _map_to_source(model_index)
-    if not src_index or not src_index.isValid():
-        # invalid index, do nothing
-        return
+    def __init__(self, sg_entity_type, field_name, display_class, editor_class,
+                 view, bg_task_manager=None):
+        """
+        Constructor
 
-    # special case for image fields
-    if widget._field_name == "image":
-        primary_item = src_index.model().item(src_index.row(), 0)
-        icon = primary_item.icon()
-        if icon:
-            widget.set_value(icon.pixmap(QtCore.QSize(256, 256)))
+        :param sg_entity_type: Shotgun entity type
+        :type sg_entity_type: String
 
-    value = src_index.data(shotgun_model.ShotgunModel.SG_ASSOCIATED_FIELD_ROLE)
-    widget.set_value(shotgun_model.sanitize_qt(value))
+        :param field_name: Shotgun field name
+        :type field_name: String
+
+        :param display_class: A shotgun field :class:`~PySide.QtGui.QWidget` to
+            display the field info
+
+        :param editor_class: A shotgun field :class:`~PySide.QtGui.QWidget` to
+            edit the field info
+
+        :param view: The parent view for this delegate
+        :type view:  :class:`~PySide.QtGui.QWidget`
+
+        :param bg_task_manager: Optional Task manager.  If this is not passed in
+            one will be created when the delegate widget is created.
+        :type bg_task_manager: :class:`~task_manager.BackgroundTaskManager`
+        """
+
+        field_data_role = shotgun_model.ShotgunModel.SG_ASSOCIATED_FIELD_ROLE
+
+        super(ShotgunFieldDelegate, self).__init__(
+            sg_entity_type, field_name, display_class, editor_class, view,
+            bg_task_manager=bg_task_manager, field_data_role=field_data_role
+        )
+
+    def setModelData(self, editor, model, index):
+        """
+        Gets data from the editor widget and stores it in the specified model at
+        the item index.
+
+        :param editor: The editor widget.
+        :type editor: :class:`~PySide.QtGui.QWidget`
+        :param model: The SG model where the data lives.
+        :type model: :class:`~PySide.QtCore.QAbstractItemModel`
+        :param index: The index of the model to be edited.
+        :type index: :class:`~PySide.QtCore.QModelIndex`
+        """
+        src_index = _map_to_source(index)
+        if not src_index or not src_index.isValid():
+            # invalid index, do nothing
+            return
+
+        # compare the new/old values to see if there is a change
+        new_value = editor.get_value()
+        cur_value = src_index.data(self.field_data_role)
+        if cur_value == new_value:
+            # value didn't change. nothing to do here.
+            return
+
+        bundle = sgtk.platform.current_bundle()
+
+        # special case for image fields in the ShotgunModel. The SG model stores
+        # the image field in the first column. If the value has changed, set the
+        # icon value there.
+        if editor.get_field_name() == "image":
+            primary_item = src_index.model().item(src_index.row(), 0)
+            try:
+                if new_value:
+                    # update the value locally in the model
+                    primary_item.setIcon(QtGui.QIcon(new_value))
+                else:
+                    primary_item.setIcon(QtGui.QIcon())
+            except Exception, e:
+                bundle.log_error(
+                    "Unable to set icon for widget delegate: %s" % (e,))
+
+            return
+
+        successful = src_index.model().setData(
+            src_index,
+            new_value,
+            self.field_data_role
+        )
+
+        if not successful:
+            bundle.log_error(
+                "Unable to set model data for widget delegate: %s, %s" %
+                (self._entity_type, self._field_name)
+            )
+
+    def _set_widget_value(self, widget, model_index):
+        """
+        Updates the supplied widget with data from the supplied model index.
+
+        :param widget: The widget to set the value for
+        :param model_index: The index of the model where the data comes from
+        :type model_index: :class:`~PySide.QtCore.QModelIndex`
+        """
+
+        src_index = _map_to_source(model_index)
+        if not src_index or not src_index.isValid():
+            # invalid index, do nothing
+            return
+
+        # special case for image fields in the ShotgunModel. The SG model has
+        # the ability to pre-query thumbnails for entities for efficiency. If
+        # this is the image field for an entity in the SG model, we can make use
+        # of the potentially pre-queried image available in the first column.
+        if widget.get_field_name() == "image":
+            primary_item = src_index.model().item(src_index.row(), 0)
+            icon = primary_item.icon()
+            if icon:
+                widget.set_value(icon.pixmap(QtCore.QSize(256, 256)))
+            return
+
+        value = src_index.data(self.field_data_role)
+        widget.set_value(shotgun_model.sanitize_qt(value))
 
 
 def _map_to_source(idx, recursive=True):
     """
-    Map the specified index to it's source model.  This can be done recursively to map
-    back through a chain of proxy models to the source model at the beginning of the chain
+    Map the specified index to it's source model.  This can be done recursively
+    to map back through a chain of proxy models to the source model at the
+    beginning of the chain
 
     :param idx: The index to map from
-    :param recursive: If true then the function will recurse up the model chain until it
-        finds an index belonging to a model that doesn't derive from QAbstractProxyModel.
-        If false then it will just return the index from the imediate parent model.
+    :param recursive: If true then the function will recurse up the model chain
+        until it finds an index belonging to a model that doesn't derive from
+        QAbstractProxyModel. If false then it will just return the index from
+        the imediate parent model.
 
-    :returns: QModelIndex in the source model or the first model in the chain that
-        isn't a proxy model if recursive is True.
+    :returns: QModelIndex in the source model or the first model in the chain
+        that isn't a proxy model if recursive is True.
     """
     src_idx = idx
-    while src_idx.isValid() and isinstance(src_idx.model(), QtGui.QAbstractProxyModel):
+    while src_idx.isValid() and isinstance(
+            src_idx.model(), QtGui.QAbstractProxyModel):
         src_idx = src_idx.model().mapToSource(src_idx)
         if not recursive:
             break
     return src_idx
-

--- a/python/shotgun_fields/shotgun_field_manager.py
+++ b/python/shotgun_fields/shotgun_field_manager.py
@@ -10,7 +10,7 @@
 
 import sgtk
 from sgtk.platform.qt import QtCore, QtGui
-from .shotgun_field_delegate import ShotgunFieldDelegate
+from .shotgun_field_delegate import ShotgunFieldDelegateGeneric, ShotgunFieldDelegate
 from .shotgun_field_editable import ShotgunFieldEditable, ShotgunFieldNotEditable
 
 shotgun_globals = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_globals")
@@ -211,6 +211,47 @@ class ShotgunFieldManager(QtCore.QObject):
             editor_class,
             view,
             bg_task_manager=self._task_manager
+        )
+
+    def create_generic_delegate(self, sg_entity_type, field_name, view, field_data_role=QtCore.Qt.EditRole):
+        """
+        Returns a delegate that can be used in the given view to show data from
+        the given field from the given entity type.  Unlike ``create_delegate``,
+        this method returns a delegate that can be used with any model
+        representing SG field data. The additional ``field_data_role`` parameter
+        is supplied to tell the delegate wich role in the model will store the
+        field data to edit/display.
+        to be used by items
+
+        :param str sg_entity_type: Shotgun entity type
+
+        :param str field_name: Shotgun field name
+
+        :param view: The parent view for this delegate
+        :type view:  :class:`~PySide.QtGui.QWidget`
+
+        :param int field_data_role: The data role that stores SG field data in
+            the model where this delegate is to be used. The default value is
+            ``QtCore.Qt.EditRole``.
+
+        :returns: A :class:``ShotgunFieldDelegateGeneric`` configured to
+            represent the given field
+        """
+        display_class = self.get_class(sg_entity_type, field_name)
+
+        if not display_class:
+            from .label_base_widget import LabelBaseWidget
+            display_class = LabelBaseWidget
+
+        editor_class = self.get_class(sg_entity_type, field_name, self.EDITOR)
+        return ShotgunFieldDelegateGeneric(
+            sg_entity_type,
+            field_name,
+            display_class,
+            editor_class,
+            view,
+            bg_task_manager=self._task_manager,
+            field_data_role=field_data_role
         )
 
     def create_label(self, sg_entity_type, field_name, prefix=None, postfix=None):

--- a/python/shotgun_fields/url_template_widget.py
+++ b/python/shotgun_fields/url_template_widget.py
@@ -11,8 +11,8 @@
 import sgtk
 from .label_base_widget import ElidedLabelBaseWidget
 from .shotgun_field_meta import ShotgunFieldMeta
-from ..utils import get_hyperlink_html
 
+utils = sgtk.platform.import_framework("tk-framework-shotgunutils", "utils")
 
 class UrlTemplateWidget(ElidedLabelBaseWidget):
     """
@@ -27,4 +27,4 @@ class UrlTemplateWidget(ElidedLabelBaseWidget):
 
         :param str value: The url value to convert into a string
         """
-        return get_hyperlink_html(url=value, name=value)
+        return utils.get_hyperlink_html(url=value, name=value)

--- a/python/version_details/version_details.py
+++ b/python/version_details/version_details.py
@@ -322,7 +322,8 @@ class VersionDetailsWidget(QtGui.QWidget):
         The currently loaded Note threads keyed by Note entity id and
         containing a list of Shotgun entity dictionaries.
 
-        Example structure containing a single Note entity:
+        Example structure containing a single Note entity::
+
             6038: [
                 {
                     'content': 'This is a test note.',
@@ -429,7 +430,7 @@ class VersionDetailsWidget(QtGui.QWidget):
         """
         Adds an action to the version tab's context menu.
 
-        Action definitions passed in must take the following form:
+        Action definitions passed in must take the following form::
 
             dict(
                 callback=callable,


### PR DESCRIPTION
* Adds a `ShotgunFieldDelegateGeneric` class that `ShotgunFieldDelegate` inherits from. The **Generic** class accepts a field data role to use for retrieving/setting data in the associated model. The `ShotgunFieldDelegate` class simply hard codes this to the role in the SG model.
* Added a manager method called `create_generic_delegate()` to make it easy for client code to create these delegates. The demo app example has been updated to use this new method:   https://github.com/shotgunsoftware/tk-multi-demo/commit/91468f
* fw docs were busted so this also includes a few tweaks to get rid of doc build errors outlined in internal ticket 40026
For reference, the original PR is here: https://github.com/shotgunsoftware/tk-framework-qtwidgets/pull/61