### PR TITLE
An alternate attempt at fixing reload issue GAME-19522. This new appr…

### DIFF
--- a/python/version_details/version_details.py
+++ b/python/version_details/version_details.py
@@ -588,9 +588,10 @@ class VersionDetailsWidget(QtGui.QWidget):
             self.clear()
             return
 
+        project_id = entity.get("project", {}).get("id") or entity.get("project")
         # Ensure project schema will be loaded. The project schema is needed
         # to reference Version fields in various UI and other elements.
-        shotgun_globals.run_on_schema_loaded(lambda : None, entity.get("project"))
+        shotgun_globals.run_on_schema_loaded(lambda : None, project_id)
 
         # Switch over to the page that contains the primary display
         # widget set now that we have data to show.


### PR DESCRIPTION
…oach does not interfere with fixes to GAME-19131. It is suspected that the statement after the or is not necessary, but left in for now for possible backwards compatibility

Fixes JIRA ticket: https://jira.autodesk.com/browse/GAME-19522

A previous attempt at a fix had been made in https://github.com/shotgunsoftware/tk-multi-versiondetails/pull/17/files, but that was in conflict with changes for https://jira.autodesk.com/browse/GAME-19131

This new approach avoids a runtime exception when calling to get the value 'project' in the entity dictionary when it does contain one but it is not a project_id, so instead the project dictionary is being queried for its 'id' value. If you look in the file there are other methods doing the same thing, which is why it seems to be the right thing to do.

The statement after the OR-assignment might be unnecessary and could be removed. It was just left there out of caution and possible backwards compatibility (it is hard to know with dynamically typed languages like python), but it is suspected that it might be unnecessary.