### PR TITLE
Exposing note selection by ID to dynamite for GAME-10898

### DIFF
--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -472,6 +472,14 @@ class ActivityStreamWidget(QtGui.QWidget):
     ############################################################################
     # public interface
 
+    def select_note(self, note_id):
+        for widget in self._activity_stream_data_widgets.values():
+            if isinstance(widget, NoteWidget):
+                match = widget.note_id == note_id
+                if match and not widget.selected:
+                    self._note_selected_changed(True, widget.note_id)
+                widget.set_selected(match)
+
     def deselect_note(self):
         """
         If a note is currently selected, it will be deselected. This will NOT

--- a/python/version_details/version_details.py
+++ b/python/version_details/version_details.py
@@ -490,6 +490,13 @@ class VersionDetailsWidget(QtGui.QWidget):
         self._requested_entity = None
         self._current_entity = None
 
+    def select_note(self, note_id):
+        """
+        Select the note identified by the id. This will trigger a note_selected
+        signal to be emitted
+        """
+        self.ui.note_stream_widget.select_note(note_id)
+
     def deselect_note(self):
         """
         If a note is currently selected, it will be deselected. This will NOT


### PR DESCRIPTION
Part of the code exposing note selection by id to dynamite. This code is related to changes in https://github.com/shotgunsoftware/tk-multi-versiondetails/pull/19

The story related to this feature is: https://jira.autodesk.com/browse/GAME-10898

@AlexPapa1000 granted permission to merge these changes in as they were needed for the milestone completion of GAME-10989. Please review and any necessary fixes or issues from the review will be made retroactively