### PR TITLE
Game-10898 expose note selection by ID

### DIFF
--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -436,12 +436,16 @@ class ActivityStreamWidget(QtGui.QWidget):
     # public interface
 
     def select_note(self, note_id):
+        selectedWidget = None
         for widget in self._activity_stream_data_widgets.values():
             if isinstance(widget, NoteWidget):
                 match = widget.note_id == note_id
                 if match and not widget.selected:
                     self._note_selected_changed(True, widget.note_id)
+                    selectedWidget = widget
                 widget.set_selected(match)
+        if selectedWidget is not None:
+            self.ui.activity_stream_scroll_area.ensureWidgetVisible(selectedWidget)
 
     def deselect_note(self):
         """

--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -435,6 +435,14 @@ class ActivityStreamWidget(QtGui.QWidget):
     ############################################################################
     # public interface
 
+    def select_note(self, note_id):
+        for widget in self._activity_stream_data_widgets.values():
+            if isinstance(widget, NoteWidget):
+                match = widget.note_id == note_id
+                if match and not widget.selected:
+                    self._note_selected_changed(True, widget.note_id)
+                widget.set_selected(match)
+
     def deselect_note(self):
         """
         If a note is currently selected, it will be deselected. This will NOT

--- a/python/version_details/version_details.py
+++ b/python/version_details/version_details.py
@@ -469,6 +469,13 @@ class VersionDetailsWidget(QtGui.QWidget):
         self._requested_entity = None
         self._current_entity = None
 
+    def select_note(self, note_id):
+        """
+        Select the note identified by the id. This will trigger a note_selected
+        signal to be emitted
+        """
+        self.ui.note_stream_widget.select_note(note_id)
+
     def deselect_note(self):
         """
         If a note is currently selected, it will be deselected. This will NOT


### PR DESCRIPTION
These changes originate from dynamite-lib pull request at https://github.com/shotgunsoftware/tk-framework-qtwidgets/pull/67

These changes are related to ticket https://jira.autodesk.com/browse/GAME-10898

It has an additional auto-scroll refinement that's not in the source PR above

Cherry-picked from dynamite lib commits 4947a423d7955b47ed19f1ae1d1016e6f01eb13e and 2dfb086fa6249ba27912d17ca729a9668dd901af

https://github.com/shotgunsoftware/tk-multi-versiondetails/pull/20 depends on the changes in this pull request