### PR TITLE
For #39721, add progress indicator to project bootstrap

### DIFF
--- a/docs/overlay_widget.rst
+++ b/docs/overlay_widget.rst
@@ -44,10 +44,18 @@ Please note that the example above is crude and for heavy computational work we 
 an asynchronous approach with a worker thread for better UI responsiveness.
 
 
-ShotgunOverlayWidget
+.. currentmodule:: overlay_widget
+
+ShotgunSpinningWidget
 ======================================
 
-.. currentmodule:: overlay_widget
+.. autoclass:: ShotgunSpinningWidget
+    :show-inheritance:
+    :members:
+    :exclude-members: paintEvent
+
+ShotgunOverlayWidget
+======================================
 
 .. autoclass:: ShotgunOverlayWidget
     :show-inheritance:

--- a/python/overlay_widget/__init__.py
+++ b/python/overlay_widget/__init__.py
@@ -10,3 +10,4 @@
 
 from .shotgun_overlay_widget import ShotgunOverlayWidget
 from .shotgun_model_overlay_widget import ShotgunModelOverlayWidget
+from .shotgun_spinning_widget import ShotgunSpinningWidget

--- a/python/overlay_widget/shotgun_overlay_widget.py
+++ b/python/overlay_widget/shotgun_overlay_widget.py
@@ -1,23 +1,25 @@
 # Copyright (c) 2013 Shotgun Software Inc.
-# 
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from tank.platform.qt import QtCore, QtGui
 
 # load resources
-from .ui import resources_rc
+from .ui import resources_rc # noqa
+from .shotgun_spinning_widget import ShotgunSpinningWidget
+
 
 class ShotgunOverlayWidget(QtGui.QWidget):
     """
     Overlay widget that can be placed on top over any QT widget.
-    Once you have placed the overlay widget, you can use it to 
-    display information, errors, a spinner etc.  
+    Once you have placed the overlay widget, you can use it to
+    display information, errors, a spinner etc.
     """
 
     MODE_OFF = 0
@@ -25,6 +27,7 @@ class ShotgunOverlayWidget(QtGui.QWidget):
     MODE_ERROR = 2
     MODE_INFO_TEXT = 3
     MODE_INFO_PIXMAP = 4
+    MODE_PROGRESS = 5
 
     def __init__(self, parent):
         """
@@ -33,12 +36,14 @@ class ShotgunOverlayWidget(QtGui.QWidget):
         """
         QtGui.QWidget.__init__(self, parent)
 
-        # hook up a listener to the parent window so we 
+        # hook up a listener to the parent window so we
         # can resize the overlay at the same time as the parent window
         # is being resized.
         filter = ResizeEventFilter(parent)
         filter.resized.connect(self._on_parent_resized)
         parent.installEventFilter(filter)
+
+        self._shotgun_spinning_widget = ShotgunSpinningWidget(self)
 
         # make it transparent
         self.setAttribute(QtCore.Qt.WA_TransparentForMouseEvents)
@@ -47,26 +52,21 @@ class ShotgunOverlayWidget(QtGui.QWidget):
         self.setVisible(False)
         self._mode = self.MODE_OFF
 
-        # setup spinner timer
-        self._timer = QtCore.QTimer(self)
-        self._timer.timeout.connect(self._on_animation)
-        self._spin_angle = 0
-
         self._message_pixmap = None
         self._message = None
         self._sg_icon = QtGui.QPixmap(":/tk_framework_qtwidgets.overlay_widget/sg_logo.png")
- 
+
     ############################################################################################
     # public interface
     def start_spin(self):
         """
         Enables the overlay and shows an animated spinner.
-        
-        If you want to stop the spinning, call :meth:`hide`. 
+
+        If you want to stop the spinning, call :meth:`hide`.
         """
-        self._timer.start(40)
-        self.setVisible(True)
+        self._shotgun_spinning_widget.start_spin()
         self._mode = self.MODE_SPIN
+        self.setVisible(True)
 
     def show_error_message(self, msg):
         """
@@ -75,16 +75,16 @@ class ShotgunOverlayWidget(QtGui.QWidget):
 
         :param msg: Message to display
         """
-        self._timer.stop()
+        self._shotgun_spinning_widget.hide()
         self.setVisible(True)
         self._message = msg
         self._mode = self.MODE_ERROR
         self.repaint()
- 
+
     def show_message(self, msg):
         """
         Display a message centered on the overlay.
-        If an error is already being displayed by the overlay at this point, 
+        If an error is already being displayed by the overlay at this point,
         nothing will happen.
 
         :param msg: Message to display
@@ -92,8 +92,8 @@ class ShotgunOverlayWidget(QtGui.QWidget):
         """
         if self._mode == self.MODE_ERROR:
             return False
-        else: 
-            self._timer.stop()
+        else:
+            self._shotgun_spinning_widget.hide()
             self.setVisible(True)
             self._message = msg
             self._mode = self.MODE_INFO_TEXT
@@ -103,17 +103,17 @@ class ShotgunOverlayWidget(QtGui.QWidget):
     def show_message_pixmap(self, pixmap):
         """
         Show an info message in the form of a pixmap.
-        If an error is already being displayed by the overlay, 
+        If an error is already being displayed by the overlay,
         the pixmap will not be shown.
 
         :param pixamp: Image to display
         :type pixmap: :class:`PySide.QtGui.QPixmap`
-        :returns: True if pixmap was displayed, False otherwise        
+        :returns: True if pixmap was displayed, False otherwise
         """
         if self._mode == self.MODE_ERROR:
             return False
-        else:         
-            self._timer.stop()
+        else:
+            self._shotgun_spinning_widget.hide()
             self.setVisible(True)
             self._message_pixmap = pixmap
             self._mode = self.MODE_INFO_PIXMAP
@@ -126,16 +126,16 @@ class ShotgunOverlayWidget(QtGui.QWidget):
 
         :param hide_errors: If set to False, errors are not hidden.
         """
-        if hide_errors == False and self._mode == self.MODE_ERROR:
+        if hide_errors is False and self._mode == self.MODE_ERROR:
             # an error is displayed - leave it up.
             return
-        self._timer.stop()
+        self._shotgun_spinning_widget.hide()
         self._mode = self.MODE_OFF
         self.setVisible(False)
- 
+
     ############################################################################################
     # internal methods
- 
+
     def _on_parent_resized(self):
         """
         Special slot hooked up to the event filter.
@@ -143,16 +143,8 @@ class ShotgunOverlayWidget(QtGui.QWidget):
         """
         # resize overlay
         self.resize(self.parentWidget().size())
+        self._shotgun_spinning_widget.resize(self.parentWidget().size())
 
-    def _on_animation(self):
-        """
-        Spinner async callback to help animate the progress spinner.
-        """
-        self._spin_angle += 1
-        if self._spin_angle == 90:
-            self._spin_angle = 0
-        self.repaint()
- 
     def paintEvent(self, event):
         """
         Render the UI.
@@ -164,31 +156,12 @@ class ShotgunOverlayWidget(QtGui.QWidget):
         painter.begin(self)
         try:
             # set up semi transparent backdrop
-            painter.setRenderHint(QtGui.QPainter.Antialiasing)
             overlay_color = QtGui.QColor("#1B1B1B")
-            painter.setBrush( QtGui.QBrush(overlay_color))
+            painter.setBrush(QtGui.QBrush(overlay_color))
             painter.setPen(QtGui.QPen(overlay_color))
             painter.drawRect(0, 0, painter.device().width(), painter.device().height())
 
-            # now draw different things depending on mode
-            if self._mode == self.MODE_SPIN:
-
-                # show the spinner
-                painter.translate((painter.device().width() / 2) - 40, 
-                                  (painter.device().height() / 2) - 40)
-
-                pen = QtGui.QPen(QtGui.QColor("#424141"))
-                pen.setWidth(3)
-                painter.setPen(pen)
-                painter.drawPixmap( QtCore.QPoint(8, 24), self._sg_icon)
-
-                r = QtCore.QRectF(0.0, 0.0, 80.0, 80.0)
-                start_angle = (0 + self._spin_angle) * 4 * 16
-                span_angle = 340 * 16 
-
-                painter.drawArc(r, start_angle, span_angle)
-
-            elif self._mode == self.MODE_INFO_TEXT:
+            if self._mode == self.MODE_INFO_TEXT:
                 # show text in the middle
                 pen = QtGui.QPen(QtGui.QColor("#888888"))
                 painter.setPen(pen)
@@ -199,20 +172,23 @@ class ShotgunOverlayWidget(QtGui.QWidget):
             elif self._mode == self.MODE_ERROR:
                 # show error text in the center
                 pen = QtGui.QPen(QtGui.QColor("#C8534A"))
-                painter.setPen(pen)            
+                painter.setPen(pen)
                 text_rect = QtCore.QRect(0, 0, painter.device().width(), painter.device().height())
                 text_flags = QtCore.Qt.AlignCenter | QtCore.Qt.AlignVCenter | QtCore.Qt.TextWordWrap
                 painter.drawText(text_rect, text_flags, self._message)
 
             elif self._mode == self.MODE_INFO_PIXMAP:
                 # draw image
-                painter.translate((painter.device().width() / 2) - (self._message_pixmap.width()/2), 
-                                  (painter.device().height() / 2) - (self._message_pixmap.height()/2) )
+                painter.translate((painter.device().width() / 2) - (self._message_pixmap.width() / 2),
+                                  (painter.device().height() / 2) - (self._message_pixmap.height() / 2))
 
-                painter.drawPixmap( QtCore.QPoint(0, 0), self._message_pixmap)
+                painter.drawPixmap(QtCore.QPoint(0, 0), self._message_pixmap)
 
         finally:
             painter.end()
+
+        return super(ShotgunOverlayWidget, self).paintEvent(event)
+
 
 class ResizeEventFilter(QtCore.QObject):
     """
@@ -222,11 +198,10 @@ class ResizeEventFilter(QtCore.QObject):
     """
     resized = QtCore.Signal()
 
-    def eventFilter(self,  obj,  event):
+    def eventFilter(self, obj, event):
         # peek at the message
         if event.type() == QtCore.QEvent.Resize:
             # re-broadcast any resize events
             self.resized.emit()
         # pass it on!
         return False
-

--- a/python/overlay_widget/shotgun_spinning_widget.py
+++ b/python/overlay_widget/shotgun_spinning_widget.py
@@ -8,6 +8,9 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
+
+import math
+
 from tank.platform.qt import QtCore, QtGui
 
 # load resources
@@ -42,6 +45,7 @@ class ShotgunSpinningWidget(QtGui.QWidget):
         self._spin_angle = 0
         self._spin_angle_to = 0
         self._previous_spin_angle_to = 0
+        self._heartbeat = 0
 
         self._sg_icon = QtGui.QPixmap(":/tk_framework_qtwidgets.overlay_widget/sg_logo.png")
 
@@ -95,6 +99,8 @@ class ShotgunSpinningWidget(QtGui.QWidget):
             # If the current spin angle has not reached the destination yet,
             # increment it, but not past.
             self._spin_angle = min(self._spin_angle_to, self._spin_angle + 1)
+            self._heartbeat = (self._heartbeat + 1) % 25
+
         self.repaint()
 
     def _draw_opened_circle(self, painter, start_angle, span_angle):
@@ -141,5 +147,31 @@ class ShotgunSpinningWidget(QtGui.QWidget):
                     # Go clockwise
                     -self._spin_angle
                 )
+
+                self._draw_heartbeat(painter)
+
         finally:
             painter.end()
+
+    def _draw_heartbeat(self, painter):
+
+        amplitude = (math.fabs(self._heartbeat - 12.5) / 12.5) * 6
+
+        angle = self._spin_angle - 90
+        y = math.sin(math.radians(angle))
+        x = math.cos(math.radians(angle))
+
+        pen = QtGui.QPen(QtGui.QColor("#424141"))
+        brush = QtGui.QBrush(QtGui.QColor("#424141"))
+        pen.setWidth(1)
+        painter.setPen(pen)
+        painter.setBrush(brush)
+
+        painter.drawEllipse(
+            QtCore.QRectF(
+                x * 40 + 40 - amplitude / 2,
+                y * 40 + 40 - amplitude / 2,
+                amplitude,
+                amplitude,
+            )
+        )

--- a/python/overlay_widget/shotgun_spinning_widget.py
+++ b/python/overlay_widget/shotgun_spinning_widget.py
@@ -1,0 +1,145 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+from tank.platform.qt import QtCore, QtGui
+
+# load resources
+from .ui import resources_rc # noqa
+
+
+class ShotgunSpinningWidget(QtGui.QWidget):
+    """
+    Overlay widget that can be placed on top over any QT widget.
+    Once you have placed the overlay widget, you can use it to
+    display information, errors, a spinner etc.
+    """
+
+    MODE_OFF = 0
+    MODE_SPIN = 1
+    MODE_PROGRESS = 2
+
+    def __init__(self, parent):
+        """
+        :param parent: Widget to attach the overlay to
+        :type parent: :class:`PySide.QtGui.QWidget`
+        """
+        QtGui.QWidget.__init__(self, parent)
+
+        # turn off the widget
+        self.setVisible(False)
+        self._mode = self.MODE_OFF
+
+        # setup spinner timer
+        self._timer = QtCore.QTimer(self)
+        self._timer.timeout.connect(self._on_animation)
+        self._spin_angle = 0
+        self._spin_angle_to = 0
+        self._previous_spin_angle_to = 0
+
+        self._sg_icon = QtGui.QPixmap(":/tk_framework_qtwidgets.overlay_widget/sg_logo.png")
+
+    ############################################################################################
+    # public interface
+    def start_spin(self):
+        """
+        Enables the overlay and shows an animated spinner.
+
+        If you want to stop the spinning, call :meth:`hide`.
+        """
+        self._timer.start(40)
+        self.setVisible(True)
+        self._mode = self.MODE_SPIN
+
+    def start_progress(self):
+        self.setVisible(True)
+        self._timer.start(40)
+        self._mode = self.MODE_PROGRESS
+        self._spin_angle_to = 0
+        self._spin_angle = 0
+
+    def report_progress(self, current):
+        self._spin_angle = max(self._previous_spin_angle_to, self._spin_angle)
+        self._previous_spin_angle_to = self._spin_angle_to
+        self._spin_angle_to = 360 * current
+        self.repaint()
+
+    def hide(self):
+        """
+        Hides the overlay.
+
+        :param hide_errors: If set to False, errors are not hidden.
+        """
+        self._timer.stop()
+        self._mode = self.MODE_OFF
+        self.setVisible(False)
+
+    ############################################################################################
+    # internal methods
+
+    def _on_animation(self):
+        """
+        Spinner async callback to help animate the progress spinner.
+        """
+        if self._mode == self.MODE_SPIN:
+            self._spin_angle += 1
+            if self._spin_angle == 90:
+                self._spin_angle = 0
+        elif self._mode == self.MODE_PROGRESS:
+            # If the current spin angle has not reached the destination yet,
+            # increment it, but not past.
+            self._spin_angle = min(self._spin_angle_to, self._spin_angle + 1)
+        self.repaint()
+
+    def _draw_opened_circle(self, painter, start_angle, span_angle):
+        # show the spinner
+        painter.translate((painter.device().width() / 2) - 40,
+                          (painter.device().height() / 2) - 40)
+
+        pen = QtGui.QPen(QtGui.QColor("#424141"))
+        pen.setWidth(3)
+        painter.setPen(pen)
+        painter.drawPixmap(QtCore.QPoint(8, 24), self._sg_icon)
+
+        r = QtCore.QRectF(0.0, 0.0, 80.0, 80.0)
+        # drawArc accepts 1/16th on angles.
+        painter.drawArc(r, start_angle * 16, span_angle * 16)
+
+    def paintEvent(self, event):
+        """
+        Render the UI.
+        """
+        if self._mode == self.MODE_OFF:
+            return
+
+        painter = QtGui.QPainter()
+        painter.begin(self)
+        try:
+            # set up semi transparent backdrop
+            painter.setRenderHint(QtGui.QPainter.Antialiasing)
+
+            # now draw different things depending on mode
+            if self._mode == self.MODE_SPIN:
+
+                self._draw_opened_circle(
+                    painter,
+                    self._spin_angle * 4,
+                    340
+                )
+
+            elif self._mode == self.MODE_PROGRESS:
+                self._draw_opened_circle(
+                    painter,
+                    # Start at noon
+                    90,
+                    # Go clockwise
+                    -self._spin_angle
+                )
+        finally:
+            painter.end()


### PR DESCRIPTION
Refactors the ShotgunOverlayWidget so that we can use the spinning part without the messaging part as the `ShotgunSpinnerWidget`. Also added the notion of progress reporting to the spinner.

This is what it looks like:
![image](https://cloud.githubusercontent.com/assets/8126447/22318623/1b90bbbe-e34a-11e6-9244-15b9321f985b.png)
The dot at the end of the line is the heartbeat which provides visual indication that the UI is not frozen if it takes a long time between two updates.
