### PR TITLE
Game 18568 fast note creation ownership

### DIFF
--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -75,7 +75,8 @@ class ActivityStreamWidget(QtGui.QWidget):
     # provided.
     #
     # dict(entity_type="Note", id=1234)
-    entity_created = QtCore.Signal(object)
+    # userdata
+    entity_created = QtCore.Signal(object, bytes)
 
     def __init__(self, parent):
         """
@@ -812,11 +813,13 @@ class ActivityStreamWidget(QtGui.QWidget):
                                                                     attachment_req["attachment_group_id"], 
                                                                     attachment_req["attachment_data"])
 
-    def _on_note_created(self, entity):
+    def _on_note_created(self, entity, userdata=None):
         """
         Callback when an entity is created by an underlying widget.
 
         :param entity:  The Shotgun entity that was created.
+        :param userdata: Optional userdata that may have been passed to the toolkit in a request
+                         to create a note.
         """
         if entity["type"] != "Note":
             # log error
@@ -825,9 +828,9 @@ class ActivityStreamWidget(QtGui.QWidget):
         self.rescan()
         if self.notes_are_selectable:
             self._select_on_arrival = entity
-        self.entity_created.emit(entity)
+        self.entity_created.emit(entity, userdata)
 
-    def create_note(self, data):
+    def create_note(self, data, userdata):
         entity_id = self._entity_id
         if entity_id is None:
             self.engine.log_debug("Skipping New Note Creation in activity stream - No entity id.")
@@ -844,7 +847,7 @@ class ActivityStreamWidget(QtGui.QWidget):
         if data["project"] is None:
             data["project"] = self._bundle.context.project
 
-        self._note_creator.submit(data)
+        self._note_creator.submit(data, userdata)
 
     ############################################################################
     # internals
@@ -1195,7 +1198,7 @@ class ActivityStreamWidget(QtGui.QWidget):
         """
         if self.notes_are_selectable and entity["type"] == "Note":
             self._select_on_arrival = entity
-        self.entity_created.emit(entity)
+        self.entity_created.emit(entity, None)
 
     def __send_note_content_to_cache_and_sg(self, sg, data):
         """

--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -1222,7 +1222,7 @@ class ActivityStreamWidget(QtGui.QWidget):
         """
         if self.notes_are_selectable and entity["type"] == "Note":
             self._select_on_arrival = entity
-        self.entity_requested.submit(entity)
+        self.entity_created.emit(entity)
         self.entity_created_internally.emit(entity, request_id)
 
     def _on_note_created_externally(self, entity, userdata=None):

--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -38,7 +38,11 @@ class ActivityStreamWidget(QtGui.QWidget):
     :signal playback_requested(dict): Fires when someone clicks the playback url
             on a version. Returns a shotgun dictionary with information
             about the version.
-    :signal entity_created(object, object): Fires when a Note or Reply entity is created by
+    :signal new_entity_requested_internally(str, int): Fires when the user has
+            triggered the creation of a new Note or Reply entity by interacting
+            with this Widget. This can be used to capture state relative to the Note
+            at the time of the action, since the creation itself is asynchronous.
+    :signal entity_created(object, object, int): Fires when a Note or Reply entity is created by
             an underlying widget within the activity stream. Returns a Shotgun dictionary
             with information about the new Entity.
     :ivar reply_dialog: When a ReplyDialog is active it can be accessed here. If there
@@ -70,15 +74,26 @@ class ActivityStreamWidget(QtGui.QWidget):
     # Called when a note is loaded either from remote download or the cache
     note_arrived = QtCore.Signal(int)
 
+    # Called when the user has initiated the creation of a new Note by interacting
+    # with this widget.
+    new_entity_requested_internally = QtCore.Signal(str, int)
+
+    # Called when entity creation triggered by this widget has completed. Passes
+    # the entity info dict and the creation request that was sent with the matching
+    # new_entity_requested_internally.
+    entity_created_internally = QtCore.Signal(object, int)
+
+    # Called when a note creation triggered via `create_note` has completed. Passes
+    # the entity info and the userdata that was passed to `create_note`.
+    note_created_externally = QtCore.Signal(object, object)
+
     # Emitted when a Note or Reply entity is created. The
     # entity type as a string and id as an int will be
     # provided.
     #
     # dict(entity_type="Note", id=1234)
     # 
-    # The second parameter is userdata bytes passed to the note creation request
-    # (may be None).
-    entity_created = QtCore.Signal(object, object)
+    entity_created = QtCore.Signal(object)
 
     def __init__(self, parent):
         """
@@ -128,6 +143,7 @@ class ActivityStreamWidget(QtGui.QWidget):
         self._data_manager.note_arrived.connect(self._process_new_note)
         self._data_manager.update_arrived.connect(self._process_new_data)
         self._data_manager.thumbnail_arrived.connect(self._process_thumbnail)
+        self.ui.note_widget.new_entity_requested.connect(self._on_new_entity_requested_internally)
         self.ui.note_widget.entity_created.connect(self._on_entity_created)
         self.ui.note_widget.data_updated.connect(self.rescan)
         
@@ -160,11 +176,12 @@ class ActivityStreamWidget(QtGui.QWidget):
         # attachments that this widget didn't explicitly handle itself prior to
         # submission.
         self._pre_submit_callback = None
+        self.reply_dialog.note_widget.new_entity_requested.connect(self._on_new_entity_requested_internally)
         self.reply_dialog.note_widget.entity_created.connect(self._on_entity_created)
 
         shotgun_model = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_model")
         self._note_creator = shotgun_model.NoteCreator()
-        self._note_creator.entity_created.connect(self._on_note_created)
+        self._note_creator.entity_created.connect(self._on_note_created_externally)
 
     def set_bg_task_manager(self, task_manager):
         """
@@ -708,6 +725,7 @@ class ActivityStreamWidget(QtGui.QWidget):
 
         note_dialog = note_input_widget.NoteInputDialog(parent=self)
         note_dialog.entity_created.connect(self._on_entity_created)
+        note_dialog.new_entity_requested.connect(self._on_new_entity_requested_internally)
         note_dialog.data_updated.connect(self.rescan)
         note_dialog.set_bg_task_manager(self._task_manager)
         note_dialog.set_current_entity(self._entity_type, self._entity_id)
@@ -826,23 +844,6 @@ class ActivityStreamWidget(QtGui.QWidget):
                     self._data_manager.request_attachment_thumbnail(attachment_req["activity_id"], 
                                                                     attachment_req["attachment_group_id"], 
                                                                     attachment_req["attachment_data"])
-
-    def _on_note_created(self, entity, userdata=None):
-        """
-        Callback when an entity is created by an underlying widget.
-
-        :param entity:  The Shotgun entity that was created.
-        :param userdata: Optional userdata that may have been passed to the toolkit in a request
-                         to create a note.
-        """
-        if entity["type"] != "Note":
-            # log error
-            return
-
-        self.rescan()
-        if self.notes_are_selectable:
-            self._select_on_arrival = entity
-        self.entity_created.emit(entity, userdata)
 
     def create_note(self, data, userdata):
         entity_id = self._entity_id
@@ -1206,7 +1207,14 @@ class ActivityStreamWidget(QtGui.QWidget):
         else:
             self.note_arrived.emit(note_id)
 
-    def _on_entity_created(self, entity):
+    def _on_new_entity_requested_internally(self, entity_type, request_id):
+        """
+        Called immediately when the user has initiated the creation of a new note,
+        before the shotgun API requests have been processed.
+        """
+        self.new_entity_requested_internally.emit(entity_type, request_id)
+
+    def _on_entity_created(self, entity, request_id):
         """
         Callback when an entity is created by an underlying widget.
 
@@ -1214,7 +1222,26 @@ class ActivityStreamWidget(QtGui.QWidget):
         """
         if self.notes_are_selectable and entity["type"] == "Note":
             self._select_on_arrival = entity
-        self.entity_created.emit(entity, None)
+        self.entity_requested.submit(entity)
+        self.entity_created_internally.emit(entity, request_id)
+
+    def _on_note_created_externally(self, entity, userdata=None):
+        """
+        Callback when an entity is created by an underlying widget.
+
+        :param entity:  The Shotgun entity that was created.
+        :param userdata: Optional userdata that may have been passed to the toolkit in a request
+                         to create a note.
+        """
+        if entity["type"] != "Note":
+            # log error
+            return
+
+        self.rescan()
+        if self.notes_are_selectable:
+            self._select_on_arrival = entity
+        self.entity_created.emit(entity)
+        self.note_created_externally.emit(entity, userdata)
 
     def __send_note_content_to_cache_and_sg(self, sg, data):
         """

--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -38,7 +38,7 @@ class ActivityStreamWidget(QtGui.QWidget):
     :signal playback_requested(dict): Fires when someone clicks the playback url
             on a version. Returns a shotgun dictionary with information
             about the version.
-    :signal entity_created(object): Fires when a Note or Reply entity is created by
+    :signal entity_created(object, object): Fires when a Note or Reply entity is created by
             an underlying widget within the activity stream. Returns a Shotgun dictionary
             with information about the new Entity.
     :ivar reply_dialog: When a ReplyDialog is active it can be accessed here. If there
@@ -75,8 +75,10 @@ class ActivityStreamWidget(QtGui.QWidget):
     # provided.
     #
     # dict(entity_type="Note", id=1234)
-    # userdata
-    entity_created = QtCore.Signal(object, bytes)
+    # 
+    # The second parameter is userdata bytes passed to the note creation request
+    # (may be None).
+    entity_created = QtCore.Signal(object, object)
 
     def __init__(self, parent):
         """

--- a/python/note_input_widget/widget.py
+++ b/python/note_input_widget/widget.py
@@ -620,7 +620,7 @@ class NoteInputWidget(QtGui.QWidget):
             self.clear()
             self._bundle.log_debug("Update call complete! Return data: %s" % data)
             self.data_updated.emit()
-            self.entity_created.emit(data["return_value"], uid)
+            self.entity_created.emit(data["return_value"], int(uid))
             if self._outgoing_tasks and self._outgoing_tasks.has(uid):
                 self._outgoing_tasks.remove(uid)
             self.__overlay.hide()

--- a/python/note_input_widget/widget.py
+++ b/python/note_input_widget/widget.py
@@ -287,7 +287,9 @@ class NoteInputWidget(QtGui.QWidget):
             self._processing_id = self.__sg_data_retriever.execute_method(self._async_submit, data)
             if self._outgoing_tasks:
                 self._outgoing_tasks.add(self._processing_id)
-            self.new_entity_requested.emit(data["entity"]["type"], self._processing_id)
+            # If the entity being acted on is a Note then we are creating a Reply, otherwise a "Note"
+            new_entity_type = "Reply" if data["entity"]["type"] == "Note" else "Note"
+            self.new_entity_requested.emit(new_entity_type, int(self._processing_id))
         else:
             raise TankError("Please associate this class with a background task processor.")
         

--- a/python/version_details/version_details.py
+++ b/python/version_details/version_details.py
@@ -84,8 +84,8 @@ class VersionDetailsWidget(QtGui.QWidget):
 
     # Emitted when an entity is created by the panel. The
     # entity type as a string and id as an int are passed
-    # along.
-    entity_created = QtCore.Signal(object)
+    # along, along with optional userdata.
+    entity_created = QtCore.Signal(object, bytes)
 
     # Emitted when an entity is loaded in the panel.
     entity_loaded = QtCore.Signal(object)
@@ -725,8 +725,8 @@ class VersionDetailsWidget(QtGui.QWidget):
         self.show_title_bar_buttons(True)
         dock_widget.dockLocationChanged.connect(self._dock_location_changed)
 
-    def create_note(self, data):
-        self.ui.note_stream_widget.create_note(data)
+    def create_note(self, data, userdata):
+        self.ui.note_stream_widget.create_note(data, userdata)
 
     def hide_note_widget(self, note_id):
         """
@@ -837,13 +837,13 @@ class VersionDetailsWidget(QtGui.QWidget):
         for attachment in attachments:
             self._attachment_uids[self._data_retriever.request_attachment(attachment)] = note_id
 
-    def _entity_created(self, entity):
+    def _entity_created(self, entity, userdata):
         """
         Emits the entity_created signal.
 
         :param dict entity: The Shotgun entity dict that was created.
         """
-        self.entity_created.emit(entity)
+        self.entity_created.emit(entity, userdata)
 
     def _field_menu_triggered(self, action):
         """

--- a/python/version_details/version_details.py
+++ b/python/version_details/version_details.py
@@ -56,9 +56,9 @@ class VersionDetailsWidget(QtGui.QWidget):
     QT Widget that displays details and Note thread data for a given Version
     entity.
 
-    :signal entity_created(object): Fires when a Note or Reply entity is created by
+    :signal entity_created(object, object): Fires when a Note or Reply entity is created by
             an underlying widget within the activity stream. Passes on a Shotgun
-            entity definition in the form of a dict.
+            entity definition in the form of a dict and optional userdata a requested note.
     :signal entity_loaded(object): Fires when a Version entity has been loaded by
             the widget. Passes on a Shotgun entity definition in the form of a dict.
     :signal note_selected(int): Fires when a Note entity is selected in the widget's
@@ -85,7 +85,7 @@ class VersionDetailsWidget(QtGui.QWidget):
     # Emitted when an entity is created by the panel. The
     # entity type as a string and id as an int are passed
     # along, along with optional userdata.
-    entity_created = QtCore.Signal(object, bytes)
+    entity_created = QtCore.Signal(object, object)
 
     # Emitted when an entity is loaded in the panel.
     entity_loaded = QtCore.Signal(object)

--- a/python/version_details/version_details.py
+++ b/python/version_details/version_details.py
@@ -874,13 +874,14 @@ class VersionDetailsWidget(QtGui.QWidget):
         """
         self.entity_created.emit(entity)
 
-    def _new_entity_requested_internally(self, entity, id):
+    def _new_entity_requested_internally(self, entity_type, id):
         """
-        Emits the entity_created signal.
+        Emits the new_entity_requested_internally signal.
 
-        :param dict entity: The Shotgun entity dict that was created.
+        :param str entity_type: The Shotgun entity type that will be created.
+        :param int id: The unique id for this note creation command.
         """
-        self.new_entity_requested_internally.emit(entity, id)
+        self.new_entity_requested_internally.emit(entity_type, id)
 
     def _entity_created_internally(self, entity, id):
         """


### PR DESCRIPTION
SG3DR needs to immediately capture the application state when a note is created, not wait until the shotgun-id is available.

When a note is created by the application, this change adds the ability for the application to pass a userdata object along with the creation request that is returned in the callback for that note creation.

When a note is created by the toolkit, e.g. by the user using the `NoteInputWidget`, new signals have been added to immediately notify the application that a note is being create, and passing note creation task Ids with the creation request and when the note is finally created.

These two pathways allow the application to synchronize and match *requests* for new notes with the *creation confirmation callbacks*.

This fixes bugs when rapidly creating notes where the application state would change and shotgun notes would become queued and take a long time to create, resulting in state mismatch of when the note was originally created.