### PR TITLE
For #40555: Only calls deleteLater of Qt objects when in Qt4.

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -27,5 +27,5 @@ requires_core_version: "v0.18.45"
  
 # the frameworks required to run this app
 frameworks:
-    - {"name": "tk-framework-shotgunutils", "version": "v5.x.x", "minimum_version": "v5.2.0"}
+    - {"name": "tk-framework-shotgunutils", "version": "v5.x.x", "minimum_version": "v5.2.2"}
 

--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -729,8 +729,14 @@ class ActivityStreamWidget(QtGui.QWidget):
                 self.ui.activity_stream_layout.removeWidget(x)
                 # set it's parent to None so that it is removed from the widget hierarchy
                 x.setParent(None)
-                # mark it to be deleted when event processing returns to the main loop
-                x.deleteLater()
+                # We've seen problems in Qt5 with deleteLater causing
+                # garbage collection of Qt objects out from under Python
+                # objects that still have active references. If we're not
+                # in Qt4, then we're going to let Qt/Python decide when to
+                # clean up instead of forcing it ourselves.
+                if QtCore.__version__.startswith("4."):
+                    # mark it to be deleted when event processing returns to the main loop
+                    x.deleteLater()
         
             self._bundle.log_debug("Clearing python data structures")
             self._activity_stream_data_widgets = {}
@@ -739,7 +745,13 @@ class ActivityStreamWidget(QtGui.QWidget):
             for w in self._activity_stream_static_widgets:
                 self.ui.activity_stream_layout.removeWidget(w)
                 w.setParent(None)
-                w.deleteLater()
+                # We've seen problems in Qt5 with deleteLater causing
+                # garbage collection of Qt objects out from under Python
+                # objects that still have active references. If we're not
+                # in Qt4, then we're going to let Qt/Python decide when to
+                # clean up instead of forcing it ourselves.
+                if QtCore.__version__.startswith("4."):
+                    w.deleteLater()
             self._activity_stream_static_widgets = []
         
         finally:
@@ -760,7 +772,13 @@ class ActivityStreamWidget(QtGui.QWidget):
             self._bundle.log_debug("Clearing the loading widget")
             self.ui.activity_stream_layout.removeWidget(self._loading_widget)
             self._loading_widget.setParent(None)
-            self._loading_widget.deleteLater()
+            # We've seen problems in Qt5 with deleteLater causing
+            # garbage collection of Qt objects out from under Python
+            # objects that still have active references. If we're not
+            # in Qt4, then we're going to let Qt/Python decide when to
+            # clean up instead of forcing it ourselves.
+            if QtCore.__version__.startswith("4."):
+                self._loading_widget.deleteLater()
             self._loading_widget = None
             self._bundle.log_debug("...done")
         

--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -26,6 +26,7 @@ from .overlaywidget import SmallOverlayWidget
 note_input_widget = sgtk.platform.current_bundle().import_module("note_input_widget")
 
 shotgun_globals = sgtk.platform.import_framework("tk-framework-shotgunutils", "shotgun_globals")
+utils = sgtk.platform.import_framework("tk-framework-shotgunutils", "utils")
 
 class ActivityStreamWidget(QtGui.QWidget):
     """
@@ -729,14 +730,7 @@ class ActivityStreamWidget(QtGui.QWidget):
                 self.ui.activity_stream_layout.removeWidget(x)
                 # set it's parent to None so that it is removed from the widget hierarchy
                 x.setParent(None)
-                # We've seen problems in Qt5 with deleteLater causing
-                # garbage collection of Qt objects out from under Python
-                # objects that still have active references. If we're not
-                # in Qt4, then we're going to let Qt/Python decide when to
-                # clean up instead of forcing it ourselves.
-                if QtCore.__version__.startswith("4."):
-                    # mark it to be deleted when event processing returns to the main loop
-                    x.deleteLater()
+                utils.safe_delete_later(x(
         
             self._bundle.log_debug("Clearing python data structures")
             self._activity_stream_data_widgets = {}
@@ -745,13 +739,8 @@ class ActivityStreamWidget(QtGui.QWidget):
             for w in self._activity_stream_static_widgets:
                 self.ui.activity_stream_layout.removeWidget(w)
                 w.setParent(None)
-                # We've seen problems in Qt5 with deleteLater causing
-                # garbage collection of Qt objects out from under Python
-                # objects that still have active references. If we're not
-                # in Qt4, then we're going to let Qt/Python decide when to
-                # clean up instead of forcing it ourselves.
-                if QtCore.__version__.startswith("4."):
-                    w.deleteLater()
+                utils.safe_delete_later(w)
+
             self._activity_stream_static_widgets = []
         
         finally:
@@ -772,13 +761,7 @@ class ActivityStreamWidget(QtGui.QWidget):
             self._bundle.log_debug("Clearing the loading widget")
             self.ui.activity_stream_layout.removeWidget(self._loading_widget)
             self._loading_widget.setParent(None)
-            # We've seen problems in Qt5 with deleteLater causing
-            # garbage collection of Qt objects out from under Python
-            # objects that still have active references. If we're not
-            # in Qt4, then we're going to let Qt/Python decide when to
-            # clean up instead of forcing it ourselves.
-            if QtCore.__version__.startswith("4."):
-                self._loading_widget.deleteLater()
+            utils.safe_delete_later(self._loading_widget)
             self._loading_widget = None
             self._bundle.log_debug("...done")
         

--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -730,7 +730,7 @@ class ActivityStreamWidget(QtGui.QWidget):
                 self.ui.activity_stream_layout.removeWidget(x)
                 # set it's parent to None so that it is removed from the widget hierarchy
                 x.setParent(None)
-                utils.safe_delete_later(x(
+                utils.safe_delete_later(x)
         
             self._bundle.log_debug("Clearing python data structures")
             self._activity_stream_data_widgets = {}

--- a/python/activity_stream/reply_list.py
+++ b/python/activity_stream/reply_list.py
@@ -23,6 +23,8 @@ from .data_manager import ActivityStreamDataHandler
 from .widget_attachment_group import AttachmentGroupWidget
 from .widget_reply import ReplyWidget
 from .overlaywidget import SmallOverlayWidget
+
+utils = sgtk.platform.import_framework("tk-framework-shotgunutils", "utils")
  
 class ReplyListWidget(QtGui.QWidget):
     """
@@ -264,14 +266,7 @@ class ReplyListWidget(QtGui.QWidget):
             self.ui.reply_layout.removeWidget(x)
             # set it's parent to None so that it is removed from the widget hierarchy
             x.setParent(None)
-            # We've seen problems in Qt5 with deleteLater causing
-            # garbage collection of Qt objects out from under Python
-            # objects that still have active references. If we're not
-            # in Qt4, then we're going to let Qt/Python decide when to
-            # clean up instead of forcing it ourselves.
-            if QtCore.__version__.startswith("4."):
-                # mark it to be deleted when event processing returns to the main loop
-                x.deleteLater()
+            utils.safe_delete_later(x)
     
         self._general_widgets = []
         self._reply_widgets = []

--- a/python/activity_stream/reply_list.py
+++ b/python/activity_stream/reply_list.py
@@ -264,8 +264,14 @@ class ReplyListWidget(QtGui.QWidget):
             self.ui.reply_layout.removeWidget(x)
             # set it's parent to None so that it is removed from the widget hierarchy
             x.setParent(None)
-            # mark it to be deleted when event processing returns to the main loop
-            x.deleteLater()
+            # We've seen problems in Qt5 with deleteLater causing
+            # garbage collection of Qt objects out from under Python
+            # objects that still have active references. If we're not
+            # in Qt4, then we're going to let Qt/Python decide when to
+            # clean up instead of forcing it ourselves.
+            if QtCore.__version__.startswith("4."):
+                # mark it to be deleted when event processing returns to the main loop
+                x.deleteLater()
     
         self._general_widgets = []
         self._reply_widgets = []

--- a/python/elided_label/elided_label.py
+++ b/python/elided_label/elided_label.py
@@ -60,7 +60,13 @@ class ElidedLabel(QtGui.QLabel):
             except Exception:
                 width = self.width()
             finally:
-                doc.deleteLater()
+                # We've seen problems in Qt5 with deleteLater causing
+                # garbage collection of Qt objects out from under Python
+                # objects that still have active references. If we're not
+                # in Qt4, then we're going to let Qt/Python decide when to
+                # clean up instead of forcing it ourselves.
+                if QtCore.__version__.startswith("4."):
+                    doc.deleteLater()
 
             self._ideal_width = width
 
@@ -214,8 +220,14 @@ class ElidedLabel(QtGui.QLabel):
             self._line_width = line_width
             return doc.toHtml()
         finally:
-            # clean up the doc:
-            doc.deleteLater()
+            # We've seen problems in Qt5 with deleteLater causing
+            # garbage collection of Qt objects out from under Python
+            # objects that still have active references. If we're not
+            # in Qt4, then we're going to let Qt/Python decide when to
+            # clean up instead of forcing it ourselves.
+            if QtCore.__version__.startswith("4."):
+                # clean up the doc:
+                doc.deleteLater()
 
     @property
     def line_width(self):

--- a/python/elided_label/elided_label.py
+++ b/python/elided_label/elided_label.py
@@ -15,6 +15,7 @@ correctly within the widget frame.  Handles rich-text.
 
 import sgtk
 from sgtk.platform.qt import QtCore, QtGui
+from sgtk.platform.qt.util import safe_delete_later
 
 class ElidedLabel(QtGui.QLabel):
     """
@@ -60,13 +61,7 @@ class ElidedLabel(QtGui.QLabel):
             except Exception:
                 width = self.width()
             finally:
-                # We've seen problems in Qt5 with deleteLater causing
-                # garbage collection of Qt objects out from under Python
-                # objects that still have active references. If we're not
-                # in Qt4, then we're going to let Qt/Python decide when to
-                # clean up instead of forcing it ourselves.
-                if QtCore.__version__.startswith("4."):
-                    doc.deleteLater()
+                safe_delete_later(doc)
 
             self._ideal_width = width
 
@@ -220,14 +215,7 @@ class ElidedLabel(QtGui.QLabel):
             self._line_width = line_width
             return doc.toHtml()
         finally:
-            # We've seen problems in Qt5 with deleteLater causing
-            # garbage collection of Qt objects out from under Python
-            # objects that still have active references. If we're not
-            # in Qt4, then we're going to let Qt/Python decide when to
-            # clean up instead of forcing it ourselves.
-            if QtCore.__version__.startswith("4."):
-                # clean up the doc:
-                doc.deleteLater()
+            safe_delete_later(doc)
 
     @property
     def line_width(self):

--- a/python/version_details/shotgun_entities/card_widget.py
+++ b/python/version_details/shotgun_entities/card_widget.py
@@ -16,6 +16,8 @@ from .ui.card_widget import Ui_ShotgunEntityCardWidget
 
 import threading
 
+utils = sgtk.platform.import_framework("tk-framework-shotgunutils", "utils")
+
 class ShotgunEntityCardWidget(QtGui.QWidget):
     """
     Simple entity widget which hosts a thumbnail, plus any requested
@@ -188,13 +190,7 @@ class ShotgunEntityCardWidget(QtGui.QWidget):
         field_widget.hide()
         self.ui.field_grid_layout.removeWidget(field_widget)
         field_widget.setParent(None)
-        # We've seen problems in Qt5 with deleteLater causing
-        # garbage collection of Qt objects out from under Python
-        # objects that still have active references. If we're not
-        # in Qt4, then we're going to let Qt/Python decide when to
-        # clean up instead of forcing it ourselves.
-        if QtCore.__version__.startswith("4."):
-            field_widget.deleteLater()
+        utils.safe_delete_later(field_widget)
 
         # If there's a label, then also remove that.
         field_label = self._fields[field_name]["label"]
@@ -203,13 +199,7 @@ class ShotgunEntityCardWidget(QtGui.QWidget):
             field_label.hide()
             self.ui.field_grid_layout.removeWidget(field_label)
             field_label.setParent(None)
-            # We've seen problems in Qt5 with deleteLater causing
-            # garbage collection of Qt objects out from under Python
-            # objects that still have active references. If we're not
-            # in Qt4, then we're going to let Qt/Python decide when to
-            # clean up instead of forcing it ourselves.
-            if QtCore.__version__.startswith("4."):
-                field_label.deleteLater()
+            utils.safe_delete_later(field_label)
 
         self.ui.field_grid_layout.setRowMinimumHeight(
             self._fields[field_name]["row"],

--- a/python/version_details/shotgun_entities/card_widget.py
+++ b/python/version_details/shotgun_entities/card_widget.py
@@ -188,7 +188,13 @@ class ShotgunEntityCardWidget(QtGui.QWidget):
         field_widget.hide()
         self.ui.field_grid_layout.removeWidget(field_widget)
         field_widget.setParent(None)
-        field_widget.deleteLater()
+        # We've seen problems in Qt5 with deleteLater causing
+        # garbage collection of Qt objects out from under Python
+        # objects that still have active references. If we're not
+        # in Qt4, then we're going to let Qt/Python decide when to
+        # clean up instead of forcing it ourselves.
+        if QtCore.__version__.startswith("4."):
+            field_widget.deleteLater()
 
         # If there's a label, then also remove that.
         field_label = self._fields[field_name]["label"]
@@ -197,7 +203,13 @@ class ShotgunEntityCardWidget(QtGui.QWidget):
             field_label.hide()
             self.ui.field_grid_layout.removeWidget(field_label)
             field_label.setParent(None)
-            field_label.deleteLater()
+            # We've seen problems in Qt5 with deleteLater causing
+            # garbage collection of Qt objects out from under Python
+            # objects that still have active references. If we're not
+            # in Qt4, then we're going to let Qt/Python decide when to
+            # clean up instead of forcing it ourselves.
+            if QtCore.__version__.startswith("4."):
+                field_label.deleteLater()
 
         self.ui.field_grid_layout.setRowMinimumHeight(
             self._fields[field_name]["row"],


### PR DESCRIPTION
We're seeing a lot of problems related to garbage collection in PySide2/Qt5 when deleteLater is used. These issues result in crashes on DCC close in some cases, but also errors on app close even when the DCC isn't being closed.