### PR TITLE
For #46757, gentler error when `tank_name` is not set.

### DIFF
--- a/python/overlay_widget/shotgun_overlay_widget.py
+++ b/python/overlay_widget/shotgun_overlay_widget.py
@@ -20,6 +20,13 @@ class ShotgunOverlayWidget(QtGui.QLabel):
     Overlay widget that can be placed on top over any QT widget.
     Once you have placed the overlay widget, you can use it to
     display information, errors, a spinner etc.
+
+    The :meth:`show_message` and :meth:`show_error_message` accept
+    both regular text and HTML to format the error message.
+
+    Constants ``INFO_COLOR`` and ``ERROR_COLOR`` are provided on the class
+    as shorthand for the colors employed by the :meth:`show_message` and
+    :meth:`show_error_message` methods.
     """
 
     MODE_OFF = 0

--- a/python/overlay_widget/shotgun_overlay_widget.py
+++ b/python/overlay_widget/shotgun_overlay_widget.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Shotgun Software Inc.
+# Copyright (c) 2018 Shotgun Software Inc.
 #
 # CONFIDENTIAL AND PROPRIETARY
 #
@@ -7,6 +7,8 @@
 # By accessing, using, copying or modifying this work you indicate your
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
 
 from tank.platform.qt import QtCore, QtGui
 
@@ -62,8 +64,11 @@ class ShotgunOverlayWidget(QtGui.QLabel):
         # Allow to open hyperlinks
         self.setOpenExternalLinks(True)
 
+        with open(os.path.join(os.path.dirname(__file__), "style.qss"), "r") as fh:
+            style = fh.read()
+
         # Dark gray background.
-        self.setStyleSheet("background-color: #1B1B1B")
+        self.setStyleSheet(style)
 
         # turn off the widget by default.
         self.hide()

--- a/python/overlay_widget/shotgun_overlay_widget.py
+++ b/python/overlay_widget/shotgun_overlay_widget.py
@@ -48,19 +48,18 @@ class ShotgunOverlayWidget(QtGui.QLabel):
 
         self._shotgun_spinning_widget = ShotgunSpinningWidget(self)
 
-        # make it transparent
+        # We want text to be centered and wrapping words.
         self.setAlignment(QtCore.Qt.AlignCenter | QtCore.Qt.AlignVCenter | QtCore.Qt.TextWordWrap)
-
-        self.setOpenExternalLinks(True)
         self.setWordWrap(True)
+
+        # Allow to open hyperlinks
+        self.setOpenExternalLinks(True)
+
+        # Dark gray background.
         self.setStyleSheet("background-color: #1B1B1B")
 
-        # turn off the widget
+        # turn off the widget by default.
         self.hide()
-
-        self._message_pixmap = None
-        self._message = None
-        self._sg_icon = QtGui.QPixmap(":/tk_framework_qtwidgets.overlay_widget/sg_logo.png")
 
     ############################################################################################
     # public interface
@@ -127,13 +126,16 @@ class ShotgunOverlayWidget(QtGui.QLabel):
         elif mode == self.MODE_INFO_TEXT:
             self.setText(
                 "<font style='color: #%s;'>%s</font>" %
-                (self.NORMAL_COLOR, payload.replace("\n", "<br>"))
+                (self.INFO_COLOR, payload.replace("\n", "<br>"))
             )
         else:
             self.setText("")
 
-        # User is trying to display something, so make the overlay visible.
-        self.setVisible(True)
+        # If the widget is not off, make it visible
+        if mode == self.MODE_OFF:
+            self.setVisible(False)
+        else:
+            self.setVisible(True)
 
         self._mode = mode
 


### PR DESCRIPTION
Refactored overlay widget into a QLabel so we can insert hyperlinks.

See [this PR](https://github.com/shotgunsoftware/tk-desktop/pull/96) to see it in action.

Here's a screenshot of the updated doc.
![screen shot 2018-03-27 at 08 50 13](https://user-images.githubusercontent.com/8126447/37968377-ecb2e834-319b-11e8-8b3b-815fc6f18a45.png)
