### PR TITLE
SG-6701 Fixes task managers leaking

### DIFF
--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -156,6 +156,7 @@ class ActivityStreamWidget(QtGui.QWidget):
         self._task_manager = task_manager
         self._data_manager.set_bg_task_manager(task_manager)
         self.ui.note_widget.set_bg_task_manager(task_manager)
+        self.reply_dialog.set_bg_task_manager(task_manager)
         
     def destroy(self):
         """

--- a/python/activity_stream/dialog_reply.py
+++ b/python/activity_stream/dialog_reply.py
@@ -95,3 +95,14 @@ class ReplyDialog(QtGui.QDialog):
         self.ui.note_widget.clear()
         # ok to close
         event.accept()
+
+    def set_bg_task_manager(self, task_manager):
+        """
+        Specify the background task manager to use to pull
+        data in the background. Data calls
+        to Shotgun will be dispatched via this object.
+        
+        :param task_manager: Background task manager to use
+        :type task_manager: :class:`~tk-framework-shotgunutils:task_manager.BackgroundTaskManager` 
+        """
+        self.ui.note_widget.set_bg_task_manager(task_manager)

--- a/python/note_input_widget/widget.py
+++ b/python/note_input_widget/widget.py
@@ -125,8 +125,14 @@ class NoteInputWidget(QtGui.QWidget):
         :param task_manager: Background task manager to use
         :type task_manager: :class:`~tk-framework-shotgunutils:task_manager.BackgroundTaskManager` 
         """
-        self.__sg_data_retriever = shotgun_data.ShotgunDataRetriever(self, 
-                                                                     bg_task_manager=task_manager)
+        # To stop the threads in self.ui.text_entry and
+        # self.__sg_data_retriever
+        self.destroy()
+
+        self.__sg_data_retriever = shotgun_data.ShotgunDataRetriever(
+            self,
+            bg_task_manager=task_manager
+        )
         
         self.__sg_data_retriever.start()
         self.__sg_data_retriever.work_completed.connect(self.__on_worker_signal)


### PR DESCRIPTION
Fixes resource leaks where no task managers were passed to widgets, causing those widgets to allocate their own task managers and subsequent threads, causing issues with unclean shutdown and resource creep/leaking.

Big shoutout and thanks to @akitisa-epic for reporting and submitting these!