### PR TITLE
SG-10692: Fix for placeholder thumb problems in the activity stream widget.

### DIFF
--- a/python/activity_stream/activity_stream.py
+++ b/python/activity_stream/activity_stream.py
@@ -110,6 +110,7 @@ class ActivityStreamWidget(QtGui.QWidget):
         self._data_manager.note_arrived.connect(self._process_new_note)
         self._data_manager.update_arrived.connect(self._process_new_data)
         self._data_manager.thumbnail_arrived.connect(self._process_thumbnail)
+        self._data_manager.requesting_ui_refresh.connect(self._clear)
         self.ui.note_widget.entity_created.connect(self._on_entity_created)
         self.ui.note_widget.data_updated.connect(self.rescan)
         


### PR DESCRIPTION
Recent changes around how thumbnails behave when they are uploaded to Shotgun has resulted in a caching-related problem in the activity stream widget. The widget maintains a persistent sqlite cache, and includes the URLs for any thumbnails associated with items in the activity stream. If the cache contained a URL to a placeholder thumbnail, it would never be purged and the user would always see the placeholder instead of the "hero" thumbnail.

The fix is to detect the placeholder thumbnail when it's downloaded. When we do, we trigger a single-shot QTimer with a 20-second interval that dumps the cache and re-queries the activity stream data from Shotgun.