### PR TITLE
[PyQt] Fix None pixmap, USING_PYQT for PyQt5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# ---- ignore special files written during config setup
+tk-metadata
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Also added `tk-metadata` to `gitignore`.

This patch fixes the following errors encountered as we try implement `tk-multi-workfiles2` "File Open..." dialog `tk-katana` for Katana 3.1 (PyQt5):

- [ ] `[ERROR python.root]: A TypeError occurred in "shotgun_overlay_widget.py": setPixmap(self, QPixmap): argument 1 has unexpected type 'NoneType'`

```python
    Traceback (most recent call last):
      File "/some/config/dir/install/app_store/tk-multi-workfiles2/v0.11.10/python/tk_multi_workfiles/entity_tree/entity_tree_form.py", line 184, in _model_about_to_reset
        self._refresh_overlay_widget.start_spin()
      File "/some/config/dir/install/git/tk-framework-qtwidgets.git/v2.8.3/python/overlay_widget/shotgun_overlay_widget.py", line 84, in start_spin
        self._set_mode(self.MODE_SPIN)
      File "/some/config/dir/install/git/tk-framework-qtwidgets.git/v2.8.3/python/overlay_widget/shotgun_overlay_widget.py", line 130, in _set_mode
        self.setPixmap(None)
    TypeError: setPixmap(self, QPixmap): argument 1 has unexpected type 'NoneType'
```
- [ ] `USING_PYQT` is incorrectly determined, resulting in `[ERROR python.root]: A TypeError occurred in "widget_delegate.py": arguments did not match any overloaded call:`
    - render(self, QPaintDevice, targetOffset: QPoint = QPoint(), sourceRegion: QRegion = QRegion(), flags: Union[QWidget.RenderFlags, QWidget.RenderFlag] = QWidget.RenderFlags(QWidget.DrawWindowBackground|QWidget.DrawChildren)): argument 1 has unexpected type 'QPainter'
    - render(self, QPainter, targetOffset: QPoint = QPoint(), sourceRegion: QRegion = QRegion(), flags: Union[QWidget.RenderFlags, QWidget.RenderFlag] = QWidget.RenderFlags(QWidget.DrawWindowBackground|QWidget.DrawChildren)): 'renderFlags' is not a valid keyword argument
```python
Traceback (most recent call last):
    File "/Volumes/wwfx/shotgun/test_project/joe/install/git/tk-framework-qtwidgets.git/v2.8.3/python/views/widget_delegate.py", line 261, in paint
    renderFlags=QtGui.QWidget.DrawChildren)
TypeError: arguments did not match any overloaded call:
    render(self, QPaintDevice, targetOffset: QPoint = QPoint(), sourceRegion: QRegion = QRegion(), flags: Union[QWidget.RenderFlags, QWidget.RenderFlag] = QWidget.RenderFlags(QWidget.DrawWindowBackground|QWidget.DrawChildren)): argument 1 has unexpected type 'QPainter'
    render(self, QPainter, targetOffset: QPoint = QPoint(), sourceRegion: QRegion = QRegion(), flags: Union[QWidget.RenderFlags, QWidget.RenderFlag] = QWidget.RenderFlags(QWidget.DrawWindowBackground|QWidget.DrawChildren)): 'renderFlags' is not a valid keyword argument
```