### PR TITLE
Documentation correction

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,7 +40,7 @@ that they are placed at the top of the file.
 
 Once you have imported the module, you can access the class or objects inside::
 
-    my_overlay = overlay.ShotgunOverlayWidget(self)
+    my_overlay = overlay_widget.ShotgunOverlayWidget(self)
 
 .. _widgets-in-designer:
 


### PR DESCRIPTION
Fix a small typo in the doc about how to use a widget form the framework.

![image](https://user-images.githubusercontent.com/6785406/64882271-c692f100-d62a-11e9-8b5f-37d574a642a4.png)
