### PR TITLE
Added HumanUser Group to the filters list for My Tasks

### DIFF
--- a/python/context_selector/context_widget.py
+++ b/python/context_selector/context_widget.py
@@ -990,11 +990,17 @@ def _query_my_tasks():
     project = bundle.context.project
     current_user = bundle.context.user
 
-    logger.debug("Querying tasks for the curren user: %s" % (current_user,))
+    logger.debug("Querying tasks for the current user: %s" % (current_user,))
 
     filters = [
         ["project", "is", project],
-        ["task_assignees", "is", current_user],
+        {
+            "filter_operator": "any",
+            "filters": [
+                ["task_assignees", "is", current_user],
+                ["task_assignees.Group.users", "is", current_user]
+            ]
+        }
     ]
 
     order = [


### PR DESCRIPTION
In tk-multi-publish2, the My Tasks context selector would not show Tasks assigned to a Group that the User belonged to. I modified the filter so that it would.