### PR TITLE
[SHOT-3163] Fix context selection with PySide2

### DIFF
--- a/python/context_selector/context_widget.py
+++ b/python/context_selector/context_widget.py
@@ -498,7 +498,7 @@ class ContextWidget(QtGui.QWidget):
         action.setIcon(QtGui.QIcon(icon_path))
         action.setData(context)
         action.triggered.connect(
-            lambda c=context: self._on_context_activated(c))
+            lambda: self._on_context_activated(context))
 
         return action
 


### PR DESCRIPTION
If I try to select a Task in the context selection widget (for example in the Publisher) in an application using PySide2, it fails and my selection is cleared. Update the python code in order to work for both PySide and PySide2