### PR TITLE
SG-13278: ensures filter returns a list

### DIFF
--- a/python/activity_stream/widget_activity_stream_base.py
+++ b/python/activity_stream/widget_activity_stream_base.py
@@ -182,26 +182,26 @@ class ActivityStreamBaseWidget(QtGui.QWidget):
             if second_diff < 10:
                 return "just now"
             if second_diff < 60:
-                return str(second_diff) + " seconds ago"
+                return "%d" % (second_diff,) + " seconds ago"
             if second_diff < 120:
                 return "a minute ago"
             if second_diff < 3600:
-                return str(second_diff / 60) + " minutes ago"
+                return str(second_diff // 60) + " minutes ago"
             if second_diff < 7200:
                 return "an hour ago"
             if second_diff < 86400:
-                return str(second_diff / 3600) + " hours ago"
+                return str(second_diff // 3600) + " hours ago"
         if day_diff == 1:
             return "Yesterday"
         if day_diff < 7:
             return str(day_diff) + " days ago"
         if day_diff < 31:
-            return str(day_diff / 7) + " weeks ago"
+            return str(day_diff // 7) + " weeks ago"
         if day_diff < 365:
-            if day_diff / 30 == 1:
+            if day_diff // 30 == 1:
                 return "1 month ago"
-            return str(day_diff / 30) + " months ago"
-        return str(day_diff / 365) + " years ago"
+            return str(day_diff // 30) + " months ago"
+        return str(day_diff // 365) + " years ago"
 
     def __generate_url(self, entity_type, entity_id, name):
         """

--- a/python/search_completer/hierarchical_search_completer.py
+++ b/python/search_completer/hierarchical_search_completer.py
@@ -146,9 +146,12 @@ class HierarchicalSearchCompleter(SearchCompleter):
 
         # When showing only entities, skip entries that aren't.
         if self._show_entities_only:
-            data_matches = filter(
-                lambda x: x["ref"]["type"] is not None and x["ref"]["id"] is not None,
-                data_matches,
+            data_matches = list(
+                filter(
+                    lambda x: x["ref"]["type"] is not None
+                    and x["ref"]["id"] is not None,
+                    data_matches,
+                )
             )
 
         if len(data_matches) == 0:


### PR DESCRIPTION
Simple fix, `filter` in Python 3 returns an iterator, not a list.