### PR TITLE
Qt 4/5 specific screen grab routines

### DIFF
--- a/python/screen_grab/screen_grab.py
+++ b/python/screen_grab/screen_grab.py
@@ -15,6 +15,8 @@ import os
 from sgtk.platform.qt import QtCore, QtGui
 import sgtk
 
+QT_MAJOR = int(QtCore.qVersion().split(".")[0])  # Works for PySide* and PyQt*
+
 
 class ScreenGrabber(QtGui.QDialog):
     """
@@ -332,10 +334,19 @@ def get_desktop_pixmap(rect):
     :returns: Captured image
     :rtype: :class:`~PySide.QtGui.QPixmap`
     """
-    desktop = QtGui.QApplication.desktop()
-    return QtGui.QPixmap.grabWindow(
-        desktop.winId(), rect.x(), rect.y(), rect.width(), rect.height()
-    )
+    x_y_w_h = rect.x(), rect.y(), rect.width(), rect.height()
+
+    if QT_MAJOR == 5:
+        screen = QtGui.QApplication.primaryScreen()
+        pixmap = screen.grabWindow(0, *x_y_w_h)
+    elif QT_MAJOR == 4:
+        desktop = QtGui.QApplication.desktop()
+        pixmap = QtGui.QPixmap.grabWindow(desktop.winId(), *x_y_w_h)
+    else:
+        message = "Screen capture not implmented for Qt %d"
+        raise NotImplementedError(message % QT_MAJOR)
+
+    return pixmap
 
 
 # Backwards compatibility, as this used to be a module-level


### PR DESCRIPTION
> This is a squash of wwfxuk's fork's 3677f70 and e9b03bc

Qt4's [QPixmap.grabWindow][pg] has been removed in Qt5 and their [Qt5 Screenshot Example] has changed to use [QScreen.grabWindow][scg].

Discovered with Katana 3.1 (PyQy5), this PR fixes the following error:

<details><summary> AttributeError: type object 'QPixmap' has no attribute 'grabWindow' </summary>

```python
An AttributeError occurred in "screen_grab.py": type object 'QPixmap' has no attribute 'grabWindow' root    2020-04-23T15:33:37
Traceback (most recent call last):
  File "/path/to/pipe/config/install/app_store/tk-framework-widget/v0.2.7/python/thumbnail_widget/thumbnail_widget.py", line 138, in _on_camera_clicked
    pm = self._on_screenshot()
  File "/path/to/pipe/config/install/app_store/tk-framework-widget/v0.2.7/python/thumbnail_widget/thumbnail_widget.py", line 230, in _on_screenshot
    pm = screen_grab.screen_capture()
  File "/path/to/pipe/config/install/git/tk-framework-qtwidgets.git/v2.8.5+wwfx.1.0.1/python/screen_grab/screen_grab.py", line 188, in screen_capture
    pixmap = get_desktop_pixmap(tool.capture_rect)
  File "/path/to/pipe/config/install/git/tk-framework-qtwidgets.git/v2.8.5+wwfx.1.0.1/python/screen_grab/screen_grab.py", line 336, in get_desktop_pixmap
    return QtGui.QPixmap.grabWindow(
AttributeError: type object 'QPixmap' has no attribute 'grabWindow'
```
</details>

![image](https://user-images.githubusercontent.com/9294702/80128538-ba421f80-858d-11ea-81db-a2718ce7230e.png)

See also:
- Do a `diff` yourself between [Qt5 Screenshot Example]'s [screenshot.cpp][src5] and [Qt4 Screenshot Example]'s [screenshot.cpp][src4]
- Our internal [v2.8.5+wwfx.1.0.2] release notes 
- Original, internal PR https://github.com/wwfxuk/tk-framework-qtwidgets/pull/4

[v2.8.5+wwfx.1.0.2]: https://github.com/wwfxuk/tk-framework-qtwidgets/releases/tag/v2.8.5%2Bwwfx.1.0.2
[Qt4 Screenshot Example]: https://doc.qt.io/archives/qt-4.8/qt-desktop-screenshot-example.html
[src4]: https://doc.qt.io/archives/qt-4.8/qt-desktop-screenshot-screenshot-cpp.html
[Qt5 Screenshot Example]: https://doc.qt.io/qt-5/qtwidgets-desktop-screenshot-example.html
[src5]: https://code.qt.io/cgit/qt/qtbase.git/plain/examples/widgets/desktop/screenshot/screenshot.cpp?h=5.14
[pg]: https://doc.qt.io/archives/qt-4.8/qpixmap.html#grabWindow
[scg]: https://doc.qt.io/qt-5/qscreen.html#grabWindow
