### PR TITLE
Bug Fix: GroupedListView bad index on _get_item_rect

### DIFF
--- a/python/views/grouped_list_view/grouped_list_view.py
+++ b/python/views/grouped_list_view/grouped_list_view.py
@@ -971,6 +971,9 @@ class GroupedListView(QtGui.QAbstractItemView):
             rows.append(index.row())
             index = index.parent()
 
+        if not rows:
+            return QtCore.QRect()
+
         # find the info for the root item:
         root_row = rows[-1]
         if root_row >= len(self._item_info):


### PR DESCRIPTION
Handle the case when `_get_item_rect` is passed an invalid index or it is the root index -- this will create an empty `rows` list which will error on `rows[-1]`