### PR TITLE
SG-18544 Title bar button size issue

### DIFF
--- a/python/version_details/resources/version_details_widget.ui
+++ b/python/version_details/resources/version_details_widget.ui
@@ -31,7 +31,7 @@
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>13</height>
+       <height>16777215</height>
       </size>
      </property>
      <property name="frameShape">
@@ -666,7 +666,6 @@
  </customwidgets>
  <resources>
   <include location="resources.qrc"/>
-  <include location="C:/Users/beelanj/.designer/backup/resources.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/python/version_details/ui/version_details_widget.py
+++ b/python/version_details/ui/version_details_widget.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'version_details_widget.ui'
 #
-#      by: pyside-uic 0.2.15 running on PySide 1.2.2
+#      by: pyside-uic 0.2.15 running on PySide 1.2.4
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -18,7 +18,7 @@ class Ui_VersionDetailsWidget(object):
         self.verticalLayout_17.setObjectName("verticalLayout_17")
         self.details_title_bar = QtGui.QFrame(VersionDetailsWidget)
         self.details_title_bar.setMinimumSize(QtCore.QSize(0, 13))
-        self.details_title_bar.setMaximumSize(QtCore.QSize(16777215, 13))
+        self.details_title_bar.setMaximumSize(QtCore.QSize(16777215, 16777215))
         self.details_title_bar.setFrameShape(QtGui.QFrame.NoFrame)
         self.details_title_bar.setFrameShadow(QtGui.QFrame.Plain)
         self.details_title_bar.setLineWidth(0)


### PR DESCRIPTION
Removed the maximum height restriction on the title bar to fix a problem of the buttons being cut off in RV

![image-2020-08-14-09-29-14-988](https://user-images.githubusercontent.com/4356899/90930986-957d7d80-e3b0-11ea-9ef4-59208ad2401b.png)
![image-2020-08-14-09-29-52-468](https://user-images.githubusercontent.com/4356899/90930987-96aeaa80-e3b0-11ea-9e45-474714a62be7.png)
