### PR TITLE
Expose additional components in search_completer

### DIFF
--- a/python/search_completer/__init__.py
+++ b/python/search_completer/__init__.py
@@ -9,4 +9,10 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from .global_search_completer import GlobalSearchCompleter
+from .global_search_result_delegate import GlobalSearchResultDelegate
 from .hierarchical_search_completer import HierarchicalSearchCompleter
+from .hierarchical_search_result_delegate import HierarchicalSearchResultDelegate
+from .search_completer import SearchCompleter
+from .search_result_delegate import SearchResultDelegate
+from .search_result_widget import SearchResultWidget
+from .utils import create_rectangular_thumbnail, CompleterPixmaps


### PR DESCRIPTION
This exposes some of the hidden modules that were previously impossible to import using `import_framework`

This allows clients to take each part of this system and potentially subclass them and swap different components in and out.


Internally in one of my own apps, I need to create my own subclass of `global_search_result_delegate.GlobalSearchResultDelegate` because the GlobalSearchCompleter when it runs the `shotgun_api3.Shotgun.text_search` it doesn't return the links result that my app needs.

Because of the way GlobalSearchCompleter works, I need to do a bunch of subclassing, and the `global_search_result_delegate` submodule was not exported by the `__init __` file.