### PR TITLE
SG-20166: global search unicode filter fix

### DIFF
--- a/python/search_completer/search_result_delegate.py
+++ b/python/search_completer/search_result_delegate.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import sgtk
+from tank_vendor import six
 
 # import the shotgun_model and view modules from the shotgun utils framework
 shotgun_model = sgtk.platform.import_framework(
@@ -38,7 +39,7 @@ class SearchResultDelegate(views.WidgetDelegate):
         super(SearchResultDelegate, self).__init__(view)
 
         self._pixmaps = CompleterPixmaps()
-        self._text = text
+        self._text = six.ensure_str(text)
 
         self.selection_model = view.selectionModel()
 


### PR DESCRIPTION
This fixes an issue where global search results with a unicode character in them would completely fail to render. Now the result will be visible and selectable. However, due to the broader issue of incorrect unicode rendering in Toolkit in Python 2, the entry search results is going to keep garbled characters instead of the expected character, as can be seen in the screenshot below.

![image](https://user-images.githubusercontent.com/8126447/98819847-64cf4200-23fb-11eb-8d89-48ae347d729d.png)

Note, the hierarchy search completer does not exhibit this bug and can properly match entries with unicode characters, so no fix was necessary.

Also, the rendering of unicode chars does not seem to be an issue in Python 3. 🙌 

![image](https://user-images.githubusercontent.com/8126447/98829313-1031c400-2407-11eb-994e-69ad05cc6eca.png)

