### PR TITLE
Fix when context entity "name" not cached

### DIFF
--- a/python/context_selector/context_widget.py
+++ b/python/context_selector/context_widget.py
@@ -626,9 +626,18 @@ class ContextWidget(QtGui.QWidget):
     def _on_entity_activated(self, entity_type, entity_id, entity_name):
         """
         Slot called when an entity is selected via one of the search completers.
+
+        Since ``context_from_entity`` doesn't guarantee "name" field to be populated,
+        fallback to use ``entity_name`` if it's missing.
         """
         bundle = sgtk.platform.current_bundle()
         context = bundle.sgtk.context_from_entity(entity_type, entity_id)
+        if entity_type == "Project":
+            context.project.setdefault("name", entity_name)
+        elif entity_type == "Task":
+            context.task.setdefault("name", entity_name)
+        else:
+            context.entity.setdefault("name", entity_name)
         self._on_context_activated(context)
 
     def _on_task_search_toggled(self, checked):


### PR DESCRIPTION
> From https://github.com/wwfxuk/tk-framework-qtwidgets/pull/7

### Fixed

- Missing context "name" when not found from path cache

```python
Traceback (most recent call last):
  File "/path/to/tk-framework-qtwidgets.git/v2.9.3/python/context_selector/context_widget.py", line 638, in _on_entity_activated
    self._on_context_activated(context)
  File "/path/to/tk-framework-qtwidgets.git/v2.9.3/python/context_selector/context_widget.py", line 629, in _on_context_activated
    self._show_context(context)
  File "/path/to/tk-framework-qtwidgets.git/v2.9.3/python/context_selector/context_widget.py", line 846, in _show_context
    link_display = _get_link_display(context)
  File "/path/to/tk-framework-qtwidgets.git/v2.9.3/python/context_selector/context_widget.py", line 908, in _get_link_display
    entity_name = entity["name"]
KeyError: 'name'
```

This can happen when the folders for an entity have not been created yet via `tank folder`, or if there's something wrong with path cache synchronisation. 

The fix focuses on making sure the GUI does not break under these circumstances.