### PR TITLE
Bug Fix: Grey out action button when in disabled state

### DIFF
--- a/python/delegates/view_item_delegate.py
+++ b/python/delegates/view_item_delegate.py
@@ -3246,5 +3246,8 @@ class ViewItemAction(object):
         :rtype: bool
         """
 
-        is_enabled = self.state(parent, index) & QtGui.QStyle.State_Enabled
-        return self.callback and is_enabled
+        if not self.callback:
+            return False
+
+        # Check if the button state is enabled
+        return self.state(parent, index) & QtGui.QStyle.State_Enabled

--- a/python/delegates/view_item_delegate.py
+++ b/python/delegates/view_item_delegate.py
@@ -3091,10 +3091,11 @@ class ViewItemAction(object):
         },
         {
             # Specific palette brushes to set for the action button. Palette brushes
-            # list items should be in the format of a tuple, e.g.:
+            # dict maps brush type to list of brush items, which should be in the
+            # format of a tuple, e.g.:
             #   (QPalette.ColorGroup, QPalette.ColorRole, QBrush)
             "key": "palette_brushes",
-            "default": [],
+            "default": {},
         },
         {
             # Flag indicating if this action should always been shown, no matter what the state is
@@ -3186,6 +3187,24 @@ class ViewItemAction(object):
         index_data = self.get_data(parent, index)
         return index_data.get("visible", True)
 
+    def state(self, parent, index):
+        """
+        Convenience method to get the state of the action for the given index.
+
+        :param parent: The parent of delegate who requested the data.
+        :type parent: :class:`sgtk.platform.qt.QtGui.QAbstractItemView`
+        :param index: The model item index
+        :type index: :class:`sgtk.platform.qt.QtCore.QModelIndex`
+
+        :return: The action state.
+        :rtype: QState
+        """
+
+        index_data = self.get_data(parent, index)
+        return index_data.get(
+            "state", QtGui.QStyle.State_Active | QtGui.QStyle.State_Enabled
+        )
+
     def get_name(self, parent, index):
         """
         Convenience method to get the current action name for the given index. The
@@ -3202,3 +3221,19 @@ class ViewItemAction(object):
 
         index_data = self.get_data(parent, index)
         return index_data.get("name", self.name)
+
+    def is_clickable(self, parent, index):
+        """
+        An action is clickable if it has a callback and is in an enabled state.
+
+        :param parent: The parent of deleaget who requested the data.
+        :type parent: :class:`sgtk.platform.qt.QtGui.QAbstractItemView`
+        :param index: The model item index
+        :type index: :class:`sgtk.platform.qt.QtCore.QModelIndex`
+
+        :return: True if the action is clickable, else False.
+        :rtype: bool
+        """
+
+        is_enabled = self.state(parent, index) & QtGui.QStyle.State_Enabled
+        return self.callback and is_enabled

--- a/python/views/grouped_list_view/grouped_item_view.py
+++ b/python/views/grouped_list_view/grouped_item_view.py
@@ -83,6 +83,7 @@ class GroupedItemView(QtGui.QAbstractItemView):
         self._border = QtCore.QSize(6, 6)
         self._group_spacing = 30
         self._item_spacing = QtCore.QSize(4, 4)
+        self._group_items_selectable = False
 
     # @property
     def _get_border(self):
@@ -128,6 +129,18 @@ class GroupedItemView(QtGui.QAbstractItemView):
         self.viewport().update()
 
     item_spacing = property(_get_item_spacing, _set_item_spacing)
+
+    @property
+    def group_items_selectable(self):
+        """
+        Get or set the property to allow group header items to be selectable or not. When set to True, group header
+        items may receive select, focus and hover events.
+        """
+        return self._group_items_selectable
+
+    @group_items_selectable.setter
+    def group_items_selectable(self, selectable):
+        self._group_items_selectable = selectable
 
     def toggle_expand(self, index):
         """
@@ -779,10 +792,21 @@ class GroupedItemView(QtGui.QAbstractItemView):
                         # ignore this error.
                         pass
 
-                    # Group items are not selectable, take focus or receive mouse hover events.
-                    option.state &= ~QtGui.QStyle.State_Selected
-                    option.state &= ~QtGui.QStyle.State_HasFocus
-                    option.state &= ~QtGui.QStyle.State_MouseOver
+                    if self.group_items_selectable:
+                        if self.selectionModel().isSelected(index):
+                            option.state |= QtGui.QStyle.State_Selected
+                        if index == self.currentIndex():
+                            option.state |= QtGui.QStyle.State_HasFocus
+                        if index == hover_index:
+                            option.state |= QtGui.QStyle.State_MouseOver
+                        else:
+                            option.state &= ~QtGui.QStyle.State_MouseOver
+                    else:
+                        # Group items are not selectable, take focus or receive mouse hover events.
+                        option.state &= ~QtGui.QStyle.State_Selected
+                        option.state &= ~QtGui.QStyle.State_HasFocus
+                        option.state &= ~QtGui.QStyle.State_MouseOver
+
                     self.itemDelegate().paint(painter, option, index)
 
                 # add the group rectangle height to the y-offset


### PR DESCRIPTION
Fix to the `ViewItemDelegate` class to render greyed out buttons when disabled.