### PR TITLE
Bug fix: Grouped item view selection

### DIFF
--- a/python/views/grouped_list_view/grouped_item_view.py
+++ b/python/views/grouped_list_view/grouped_item_view.py
@@ -671,7 +671,6 @@ class GroupedItemView(QtGui.QAbstractItemView):
                     index = self.model().index(row, 0)
                     selection.select(index, index)
                     y_offset += self._item_spacing.height() + self._group_spacing
-                    continue
 
             # check for selection of child items
             y_offset += item_info.rect.height()


### PR DESCRIPTION
* Need to continue after selecting the group to ensure the y offset is updated to avoid selecting indexes that are not in the selection intersection