### PR TITLE
SG-27819: Fix duplicate filter name

### DIFF
--- a/python/filtering/filter_definition.py
+++ b/python/filtering/filter_definition.py
@@ -471,7 +471,13 @@ class FilterDefinition(object):
                         )
 
                 if not field_display.startswith(entity_display):
-                    field_display = "{} {}".format(entity_display, field_display)
+                    field_display = "{entity} {field}".format(
+                        entity=entity_display, field=field_display
+                    )
+                else:
+                    field_display = "{entity_and_field} ({field})".format(
+                        entity_and_field=field_display, field=sg_field
+                    )
 
             self._add_filter_definition(
                 field_id, sg_field, field_display, data_type, value, role


### PR DESCRIPTION
* Filter names are built based on the entity display and field display names, but there are some cases where the name will be duplicated if the field display name already includes the entity name. In this case (where the entity name is already included in the field display), we will append the field name (not display name) in brackets