### PR TITLE
SG-29407: Improve delegate handing of mouse mouse events.

### DIFF
--- a/python/delegates/view_item_delegate.py
+++ b/python/delegates/view_item_delegate.py
@@ -1388,13 +1388,6 @@ class ViewItemDelegate(QtGui.QStyledItemDelegate):
             painter.drawRect(rect)
             painter.restore()
 
-        # Emit a data changed signal for the index to continue painting the animation until
-        # the item has finished loading.
-        # TODO: leverage the 'roles' parameter to emit only the relevant data roles
-        # to consider, for a more efficient update. Currently there are some issues using
-        # this parameter due to mismatch method signatures between versions.
-        index.model().dataChanged.emit(index, index)
-
     def _draw_separator(self, painter, option, index):
         """
         Draw a line to separate this view item from the next. This default implementation will

--- a/python/delegates/view_item_delegate.py
+++ b/python/delegates/view_item_delegate.py
@@ -1158,13 +1158,6 @@ class ViewItemDelegate(QtGui.QStyledItemDelegate):
                 else:
                     widget.unsetCursor()
 
-            # Emit a data changed signal for the index to paint according to the mouse move
-            # event (e.g. hover selection).
-            # TODO: leverage the 'roles' parameter to emit only the relevant data roles
-            # to consider, for a more efficient update. Currently there are some issues using
-            # this parameter due to mismatch method signatures between versions.
-            model.dataChanged.emit(index, index)
-
             # Fall through to allow the base implementation to perform any other mouse move event handling
 
         return super(ViewItemDelegate, self).editorEvent(

--- a/python/views/grouped_list_view/grouped_item_view.py
+++ b/python/views/grouped_list_view/grouped_item_view.py
@@ -785,7 +785,7 @@ class GroupedItemView(QtGui.QAbstractItemView):
                 viewport_pos = self.viewport().mapFromGlobal(global_pos)
                 hover_index = self.indexAt(viewport_pos)
 
-                if rect.isValid and rect.intersects(viewport_rect):
+                if rect.isValid() and rect.intersects(viewport_rect):
                     # the group widget is visible
                     option = self._get_view_options()
                     option.rect = rect

--- a/python/views/grouped_list_view/grouped_item_view.py
+++ b/python/views/grouped_list_view/grouped_item_view.py
@@ -785,7 +785,7 @@ class GroupedItemView(QtGui.QAbstractItemView):
                 viewport_pos = self.viewport().mapFromGlobal(global_pos)
                 hover_index = self.indexAt(viewport_pos)
 
-                if rect.isValid() and rect.intersects(viewport_rect):
+                if rect.isValid() and rect.intersects(update_rect):
                     # the group widget is visible
                     option = self._get_view_options()
                     option.rect = rect


### PR DESCRIPTION
* Do not emit data changed signal on mouse move event, this is not necessary and causes the UI responsiveness to be slow (due to extra paint events being triggered)
* We cannot use the `roles` parameter to specify what data has changed when emitting the `dataChanged` signal since tk-core patches this method and ignores this parameter
* Fix method call