### PR TITLE
SearchWidget emit search changed signal on editing finished

### DIFF
--- a/python/search_widget/search_widget.py
+++ b/python/search_widget/search_widget.py
@@ -70,6 +70,7 @@ class SearchWidget(QtGui.QWidget):
 
         # hook up the signals:
         self._ui.search_edit.textEdited.connect(self._on_text_edited)
+        self._ui.search_edit.editingFinished.connect(self._on_editing_finished)
         self._ui.search_edit.returnPressed.connect(self._on_return_pressed)
         self._clear_btn.clicked.connect(self._on_clear_clicked)
 
@@ -123,12 +124,23 @@ class SearchWidget(QtGui.QWidget):
         self._clear_btn.setVisible(bool(text))
         self.search_edited.emit(text)
 
+    def _on_editing_finished(self):
+        """
+        Slot triggered when editing has finished.
+        """
+        self._on_search_changed()
+
     def _on_return_pressed(self):
         """
         Slot triggered when return has been pressed
         """
-        self.search_changed.emit(self.search_text)
+        self._on_search_changed()
+    
+    def _on_search_changed(self):
+        """Emit signal that search text has changed with the current text value."""
 
+        self.search_changed.emit(self.search_text)
+    
     def _safe_to_string(self, value):
         """
         Safely convert the value to a string - handles

--- a/python/search_widget/search_widget.py
+++ b/python/search_widget/search_widget.py
@@ -135,12 +135,12 @@ class SearchWidget(QtGui.QWidget):
         Slot triggered when return has been pressed
         """
         self._on_search_changed()
-    
+
     def _on_search_changed(self):
         """Emit signal that search text has changed with the current text value."""
 
         self.search_changed.emit(self.search_text)
-    
+
     def _safe_to_string(self, value):
         """
         Safely convert the value to a string - handles


### PR DESCRIPTION
* Provide the option to listen for editing finished signal for whole text changes, instead of each new key stroke
* Update the `search_changed` signal to emit when the line edit sends the `editingFinished` signal

This change may help address this issue: https://community.shotgridsoftware.com/t/removing-the-search-widget-in-tk-multi-workfiles2/16478