### PR TITLE
Config 1.6.1 RC3 - Linux - The Loader and the Shotgun panel fail to load and the Publishing does not work

### DIFF
--- a/python/filtering/filter_menu.py
+++ b/python/filtering/filter_menu.py
@@ -1141,7 +1141,7 @@ class FilterMenu(NoCloseOnActionTriggerShotgunMenu):
         :return: The field id that the search filter item widget refers to.
         :rtype: str
         """
-        return re.sub(rf".{str(SearchFilterItemWidget)}$", "", filter_id)
+        return re.sub(r"{}$".format(str(SearchFilterItemWidget)), "", filter_id)
 
     def _get_filter_group_items(self, field_id):
         """

--- a/python/utils.py
+++ b/python/utils.py
@@ -312,12 +312,12 @@ def sg_field_to_str(sg_type, sg_field, value, directive=None):
         if "icon" in directives:
             # Show the entity icon
             icon_url = shotgun_globals.get_entity_type_icon_url(entity_type)
-            icon_str = f"<img src='{icon_url}' />"
+            icon_str = "<img src='{}' />".format(icon_url)
             str_val = " ".join([icon_str, str_val])
         elif "icon_suffix" in directives:
             # Show icon as suffix
             icon_url = shotgun_globals.get_entity_type_icon_url(entity_type)
-            icon_str = f"<img src='{icon_url}' />"
+            icon_str = "<img src='{}' />".format(icon_url)
             str_val = " ".join([str_val, icon_str])
 
     elif isinstance(value, list):
@@ -376,12 +376,12 @@ def sg_field_to_str(sg_type, sg_field, value, directive=None):
         if "icon" in directives:
             # Show the entity icon
             icon_url = shotgun_globals.get_entity_type_icon_url(sg_type)
-            icon_str = f"<img src='{icon_url}' />"
+            icon_str = "<img src='{}' />".format(icon_url)
             str_val = " ".join([icon_str, str_val])
         elif "icon_suffix" in directives:
             # Show icon as suffix
             icon_url = shotgun_globals.get_entity_type_icon_url(sg_type)
-            icon_str = f"<img src='{icon_url}' />"
+            icon_str = "<img src='{}' />".format(icon_url)
             str_val = " ".join([str_val, icon_str])
 
     return str_val


### PR DESCRIPTION
This PR addresses a bug encountered during the testing of the config v1.6.1-rc3 . This bug caused a SyntaxError in older versions of Houdini (17.5.460) and Nuke (12.0v8), which both still rely on Python 2.7.