### PR TITLE
Fix ensure_str as encoding parameter is incorrect

### DIFF
--- a/python/filtering/filter_item_widget.py
+++ b/python/filtering/filter_item_widget.py
@@ -189,7 +189,7 @@ class ChoicesFilterItemWidget(FilterItemWidget):
             layout.addWidget(icon_label)
 
         # Left-aligned filter value display text
-        name = six.ensure_str(self._display_name, self._raw_value)
+        name = six.ensure_str(self._display_name)
         self.label = QtGui.QLabel(name)
         layout.addWidget(self.label)
 


### PR DESCRIPTION
There is an error with the use of six's `ensure_str`. I believe some thought the second parameter was going to be an encoding value but `self._raw_value` is never the encoding value.