### PR TITLE
SG-34515 Fix forwarding signal to support both PySide2/6

### DIFF
--- a/python/filtering/filter_item_widget.py
+++ b/python/filtering/filter_item_widget.py
@@ -25,7 +25,7 @@ class FilterItemWidget(QtGui.QWidget):
     """
 
     # Signal emitted when the filter widget's checkbox state changed.
-    state_changed = QtCore.Signal(int)
+    state_changed = QtCore.Signal(QtCore.Qt.CheckState)
     # Signal emitted when the filter widget's value changed.
     value_changed = QtCore.Signal(object)
 
@@ -178,7 +178,11 @@ class ChoicesFilterItemWidget(FilterItemWidget):
 
         # Left-aligned checkbox
         self.checkbox = QtGui.QCheckBox()
-        self.checkbox.stateChanged.connect(self.state_changed)
+        def __on_state_changed(state):
+            if isinstance(state, int):
+                state = QtCore.Qt.CheckState(state)
+            self.state_changed.emit(state)
+        self.checkbox.stateChanged.connect(__on_state_changed)
         layout.addWidget(self.checkbox)
 
         # Left-aligned (optional) icon

--- a/python/filtering/filter_item_widget.py
+++ b/python/filtering/filter_item_widget.py
@@ -178,10 +178,12 @@ class ChoicesFilterItemWidget(FilterItemWidget):
 
         # Left-aligned checkbox
         self.checkbox = QtGui.QCheckBox()
+
         def __on_state_changed(state):
             if isinstance(state, int):
                 state = QtCore.Qt.CheckState(state)
             self.state_changed.emit(state)
+
         self.checkbox.stateChanged.connect(__on_state_changed)
         layout.addWidget(self.checkbox)
 


### PR DESCRIPTION
* To support PySide2, we must forward the signal state parameter as an int; however, this override the PySide6 patch to pass the state parameter as a QtCore.Qt.CheckState object
* The underlying issue is that the QtCore.Qt.CheckState object changed in PySide2 from a class object to an enum object. In PySide2, we could campare an int to the QtCore.Qt.CheckState, but this is no longer the case in PySide6
* To support both, we need to manually intercept the stateChanged signal and convert the state paramter to a QtCore.Qt.CheckState (even though this is already done in the pyside6 patcher)