### PR TITLE
SG-34637 qt6  mac closing multi workfiles2 makes maya crash

### DIFF
--- a/python/models/hierarchical_filtering_proxy_model.py
+++ b/python/models/hierarchical_filtering_proxy_model.py
@@ -344,7 +344,9 @@ class HierarchicalFilteringProxyModel(QtGui.QSortFilterProxyModel):
                 prev_source_model.rowsInserted.disconnect(
                     self._on_source_model_rows_inserted
                 )
-                prev_source_model.dataChanged.disconnect(self._on_source_model_data_changed)
+                prev_source_model.dataChanged.disconnect(
+                    self._on_source_model_data_changed
+                )
                 prev_source_model.modelAboutToBeReset.disconnect(
                     self._on_source_model_about_to_be_reset
                 )

--- a/python/models/hierarchical_filtering_proxy_model.py
+++ b/python/models/hierarchical_filtering_proxy_model.py
@@ -340,13 +340,17 @@ class HierarchicalFilteringProxyModel(QtGui.QSortFilterProxyModel):
         # if needed, disconnect from the previous source model:
         prev_source_model = self.sourceModel()
         if prev_source_model:
-            prev_source_model.rowsInserted.disconnect(
-                self._on_source_model_rows_inserted
-            )
-            prev_source_model.dataChanged.disconnect(self._on_source_model_data_changed)
-            prev_source_model.modelAboutToBeReset.disconnect(
-                self._on_source_model_about_to_be_reset
-            )
+            try:
+                prev_source_model.rowsInserted.disconnect(
+                    self._on_source_model_rows_inserted
+                )
+                prev_source_model.dataChanged.disconnect(self._on_source_model_data_changed)
+                prev_source_model.modelAboutToBeReset.disconnect(
+                    self._on_source_model_about_to_be_reset
+                )
+            except RuntimeError:
+                app = sgtk.platform.current_bundle()
+                app.log_debug("Error running closeEvent()")
 
         # clear out the various caches:
         self._dirty_all_accepted()


### PR DESCRIPTION
This is a workaround for the issue in Maya where it crashes when attempting to disconnect signals in the closeEvent method. It seems that the signals were already being disconnected. After handling the exception, the application's functionality remains unaffected.
