### PR TITLE
SG-35731 Update required tk-framework-shotgunutils version

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -27,4 +27,4 @@ requires_core_version: "v0.21.4"
 
 # the frameworks required to run this app
 frameworks:
-    - {"name": "tk-framework-shotgunutils", "version": "v5.x.x", "minimum_version": "v5.2.2"}
+    - {"name": "tk-framework-shotgunutils", "version": "v5.x.x", "minimum_version": "v5.10.0"}


### PR DESCRIPTION
#163 removes usages for `safe_delete_later` function, also removed on https://github.com/shotgunsoftware/tk-framework-shotgunutils/pull/155

We forgot to restrict the framework version requirements.