### PR TITLE
SG-35973 Don't use ensure_str to prevent crashing

### DIFF
--- a/python/filtering/filter_item_widget.py
+++ b/python/filtering/filter_item_widget.py
@@ -195,7 +195,7 @@ class ChoicesFilterItemWidget(FilterItemWidget):
             layout.addWidget(icon_label)
 
         # Left-aligned filter value display text
-        name = six.ensure_str(self._display_name)
+        name = str(self._display_name)
         self.label = QtGui.QLabel(name)
         layout.addWidget(self.label)
 


### PR DESCRIPTION
If a task doesn't have a status set on SG, or tags, or the PublishedFile has no tags, they will be recognized as `None` in the breakdown2 component.

> This only happens when the user manually changes the PublishedFile version to `0` for their own purposes.

It seems it was working before this change: https://github.com/shotgunsoftware/tk-multi-breakdown2/pull/65. Adding @staceyoue as reviewer here.

|--|--|
|![image](https://github.com/user-attachments/assets/5fe8c72b-60c7-452a-adfd-22001a3bb32a) | ![image](https://github.com/user-attachments/assets/832fa4cb-efb5-41f7-a588-d2b75e98e74e)|
|--|--|

Using `six.ensure_str` breaks as it doesn't support a `None` type. This change attempts to fix this.

![image](https://github.com/user-attachments/assets/517d96b0-dcae-4ea2-a735-a749b87ba73e)
